### PR TITLE
fix(n8n-workflow-lifecycle): correct tag capability in MCP

### DIFF
--- a/skills/n8n-workflow-lifecycle/SKILL.md
+++ b/skills/n8n-workflow-lifecycle/SKILL.md
@@ -72,7 +72,7 @@ For full conventions (verb-noun patterns, capitalization, prefixes), read `refer
 - **Workflows:** verb-first, scoped. `Send weekly customer report` not `Customer report sender`.
 - **Nodes:** describe what they *do* in this workflow, not the node type. `Fetch active customers` not `Postgres1`.
 - **Sub-workflows:** prefix with the domain or `Subworkflow:` for stateless reusable ones. `Subworkflow: Parse RFC2822 date`. The prefix is what `search_workflows({ query })` matches on. See `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
-- **Tags:** UI-only. The MCP can't read or write tags, so they're for humans browsing the UI. Don't rely on them for AI discovery.
+- **Tags:** the MCP can both read and write tags. Read with `list_tags` (every tag + `usageCount`) and `search_workflows({ tags })` (AND semantics; result items also include their `tags`). Write with `update_workflow`'s `addTags` / `removeTags` operations (a tag that doesn't exist yet is created). Two caveats: `create_workflow_from_code` has no tag parameter, so tag *after* creating via `update_workflow`; and `get_workflow_details` does **not** surface tags (it returns `tags: []` even when tags are attached), so verify applied tags with `list_tags` (check `usageCount`) or `search_workflows`. Tags remain primarily a human-facing organization tool — for AI discovery still prefer naming + `description` with `search_workflows({ query })`, using `tags` as a secondary filter.
 
 ## Readability: descriptions, sticky notes, conventions
 


### PR DESCRIPTION
## Summary

The `n8n-workflow-lifecycle` skill tells agents that workflow tags are read-only-via-UI:

> **Tags:** UI-only. The MCP can't read or write tags, so they're for humans browsing the UI. Don't rely on them for AI discovery.

This is no longer true. The n8n MCP server gained tag support in [n8n-io/n8n#31446](https://github.com/n8n-io/n8n/pull/31446) (and follow-ups):

- **Read:** `list_tags`, and `search_workflows({ tags })` (AND semantics; result items also expose their `tags`).
- **Write:** `update_workflow` `addTags` / `removeTags` operations (a not-yet-existing tag is created on use).

The stale line led an agent to incorrectly tell a user "the MCP can't set tags, add it in the UI" — when `update_workflow` with `addTags` does exactly that.

## Change

Replace the bullet with accurate read/write guidance, plus the two real gotchas worth warning agents about:

1. `create_workflow_from_code` has **no** tag parameter — tag *after* creating, via `update_workflow`.
2. `get_workflow_details` does **not** surface tags (returns `tags: []` even when tags are attached) — verify applied tags via `list_tags` (`usageCount`) or `search_workflows`.

Tags are still framed as primarily a human-facing organization tool, with naming + `description` preferred for AI discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)