### PR TITLE
fix(n8n-workflow-lifecycle): correct tag capability in MCP

### DIFF
--- a/skills/n8n-workflow-lifecycle/SKILL.md
+++ b/skills/n8n-workflow-lifecycle/SKILL.md
@@ -72,7 +72,7 @@ For full conventions (verb-noun patterns, capitalization, prefixes), read `refer
 - **Workflows:** verb-first, scoped. `Send weekly customer report` not `Customer report sender`.
 - **Nodes:** describe what they *do* in this workflow, not the node type. `Fetch active customers` not `Postgres1`.
 - **Sub-workflows:** prefix with the domain or `Subworkflow:` for stateless reusable ones. `Subworkflow: Parse RFC2822 date`. The prefix is what `search_workflows({ query })` matches on. See `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
-- **Tags:** UI-only. The MCP can't read or write tags, so they're for humans browsing the UI. Don't rely on them for AI discovery.
+- **Tags:** the MCP reads tags (`list_tags`, `search_workflows({ tags })`) and writes them (`update_workflow` `addTags`/`removeTags`; missing tags are created). Caveats: `create_workflow_from_code` takes no tag param (tag afterward via `update_workflow`), and `get_workflow_details` returns `tags: []` even when tags exist — verify with `list_tags` or `search_workflows`.
 
 ## Readability: descriptions, sticky notes, conventions
 


### PR DESCRIPTION
## Summary

The `n8n-workflow-lifecycle` skill states tags are read-only-via-UI:

> **Tags:** UI-only. The MCP can't read or write tags [...]

This is outdated. The n8n MCP gained tag support in [n8n-io/n8n#31446](https://github.com/n8n-io/n8n/pull/31446): reads via `list_tags` / `search_workflows({ tags })`, writes via `update_workflow` `addTags`/`removeTags`.

## Change

Replace the bullet with concise, accurate guidance matching the file's style, including the two gotchas: `create_workflow_from_code` has no tag param, and `get_workflow_details` returns `tags: []` even when tags are attached (verify via `list_tags` / `search_workflows`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)