### PR TITLE
docs: sync skill docs with list_tags tool and search_workflows tags filter (PR #31446)

### DIFF
--- a/skills/n8n-extending-mcp/SKILL.md
+++ b/skills/n8n-extending-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: n8n-extending-mcp
-description: 'Use when you want to expose an n8n workflow as a tool the coding agent can call. Two cases. (1) Wrap n8n API capabilities the MCP doesn''t natively expose: folder CRUD, tag CRUD, instance metadata, credential creation. (2) Expose a general-purpose workflow as an agent tool: a workflow that calls a third-party API, runs business logic, or does any task you want the agent to invoke. Triggers on "expose as MCP tool", "build a tool for my agent", "I need to know X" where X isn''t an MCP tool, "create folder", "create tag", or any capability gap.'
+description: 'Use when you want to expose an n8n workflow as a tool the coding agent can call. Two cases. (1) Wrap n8n API capabilities the MCP doesn''t natively expose: folder CRUD, tag CRUD (create, get, delete), instance metadata, credential creation. (2) Expose a general-purpose workflow as an agent tool: a workflow that calls a third-party API, runs business logic, or does any task you want the agent to invoke. Triggers on "expose as MCP tool", "build a tool for my agent", "I need to know X" where X isn''t an MCP tool, "create folder", "create tag", or any capability gap.'
 ---
 
 <!-- TEMPORARY: update whenever n8n mcp capacities are added. a lot of listed functionalities missing are coming soon -->
@@ -8,7 +8,7 @@ description: 'Use when you want to expose an n8n workflow as a tool the coding a
 
 Any n8n workflow with MCP access enabled becomes a tool the coding agent can call by name. Two common cases:
 
-1. **Wrap n8n capabilities the MCP doesn't expose.** The MCP covers workflow CRUD, validation, execution, data tables, credential listing, execution search, folder/project listing. Still missing: folder CRUD, tag CRUD, instance metadata, credential creation. Build a workflow that hits the n8n API and exposes the result as an agent tool.
+1. **Wrap n8n capabilities the MCP doesn't expose.** The MCP covers workflow CRUD, validation, execution, data tables, credential listing, execution search, folder/project listing, and tag listing (`list_tags`). Still missing: folder CRUD, tag create/delete, instance metadata, credential creation. Build a workflow that hits the n8n API and exposes the result as an agent tool.
 2. **Expose a general-purpose workflow as a tool.** A workflow that has nothing to do with n8n itself (calls a third-party API, runs internal business logic, looks something up in a private system) can be MCP-callable. Lets the agent invoke real operations during a coding session.
 
 The MCP calls your workflow as if it were a native tool: input from the `Execute Workflow Trigger`, output from the workflow's last node.
@@ -18,7 +18,7 @@ The MCP calls your workflow as if it were a native tool: input from the `Execute
 Case 1 (wrap n8n capability):
 
 - Folder CRUD (create, rename, move, delete): REST API exists, no MCP tool yet.
-- Tag CRUD (create, list, get, delete): REST API exists, no MCP tool yet.
+- Tag create/delete: REST API exists, no MCP tool yet. (Tag listing is now available natively via `list_tags`.)
 - Instance metadata (limits, plan info, configured integrations): no MCP tool.
 - Credential creation: REST API exists (`POST /credentials`), no MCP tool yet.
 - Any n8n API operation the MCP doesn't natively expose.
@@ -96,7 +96,7 @@ Output: { version, edition, integrations: [...], limits: {...} }
 
 The MCP **doesn't register each tool-flagged workflow as a separately-named MCP tool.** Discovery and invocation are two steps:
 
-1. **Discover** via `search_workflows({ query: '<keyword>' })`. Workflows with MCP access on return `availableInMCP: true`. Filter for that.
+1. **Discover** via `search_workflows({ query: '<keyword>' })` or `search_workflows({ tags: ['<tag>'] })`. Workflows with MCP access on return `availableInMCP: true`. Filter for that.
 2. **Invoke** via `execute_workflow({ workflowId, inputs })`. Read the input schema first with `get_workflow_details`. The `Execute Workflow Trigger` defines typed fields.
 
 Output is whatever the workflow's last node returns.
@@ -116,4 +116,3 @@ Output is whatever the workflow's last node returns.
 | Wrapper that does bulk or destructive ops (archive, delete) with no dry-run | One bug touches many workflows | Strong explicit opt-in per call, plus a dry-run mode that lists targets without acting |
 | Wrapper returns credential *values* | Token leak via tool output | Return IDs, names, types only. Never the secret. |
 | Skipping the validate + verify + test cycle on the wrapper | The "tool" itself is broken, manifests as confusing tool-not-found or empty-response errors | Same lifecycle as any workflow: see `n8n-workflow-lifecycle` |
-

--- a/skills/n8n-subworkflows/SKILL.md
+++ b/skills/n8n-subworkflows/SKILL.md
@@ -3,8 +3,6 @@ name: n8n-subworkflows
 description: Use when building anything multi-step, anything that looks repeatable, anything the user mentions reusing, or any workflow with more than ~10 nodes. Triggers on "reuse", "I do this in another workflow", "extract", "modular", "shared logic", "subworkflow", multi-step builds, or any task that mentions logic the user has built before.
 ---
 
-<!-- TEMPORARY: change workflow prefix searching to tags when tag tools are added to mcp -->
-
 # n8n Sub-workflows
 
 Sub-workflows are reusable functions. The `Execute Workflow Trigger` declares input parameters, the body does work, the last node returns output. Callers invoke it like any other node.
@@ -15,7 +13,7 @@ Without sub-workflows, the same logic gets duplicated across workflows. Bug fixe
 
 ## Non-negotiables
 
-1. **Search before you build.** Before writing logic that handles a generic problem, check if a sub-workflow already exists. Use `search_workflows({ query: 'Subworkflow' })`, `query: '<keyword>'`, etc. The MCP can't filter by tags, so naming is the discovery mechanism.
+1. **Search before you build.** Before writing logic that handles a generic problem, check if a sub-workflow already exists. Use `search_workflows({ query: 'Subworkflow' })`, `query: '<keyword>'`, or `search_workflows({ tags: ['<tag>'] })` to filter by tag. The MCP can also list all tags via `list_tags` to discover what categories exist.
 2. **`Execute Workflow Trigger` uses "Define Below" with typed fields, not passthrough.** Define Below is the only mode that lets agent tools (`fromAi`) and structured callers pass values in. Two exceptions: (a) the sub-workflow specifically needs to receive binary (then it can't be wired as an agent tool directly), or (b) the sub-workflow takes no inputs at all (Define Below requires at least one field). See "Sub-workflow inputs and outputs" below.
 
 ## Strong defaults
@@ -24,6 +22,7 @@ Without sub-workflows, the same logic gets duplicated across workflows. Bug fixe
 - **Default to stateless for pure logic** (input → output, no external state). For state-touching logic, build *deliberately* stateful sub-workflows that abstract the operation behind a clean contract (the ORM / repository pattern). What to avoid is *accidental* state: a "validate" sub-workflow that quietly writes to a log table.
 - **Verb-first prefix naming**: `Subworkflow: Parse RFC2822 date`, `Customer: hydrate from Stripe`, `Tool: list available credentials`. The prefix is what `search_workflows` matches on. See `references/NAMING_AND_DISCOVERY.md`.
 - **Description carries keywords.** Input/output shape + representative terms, so varied queries surface it.
+- **Use tags for categorization.** Tags are MCP-accessible: `list_tags` lists all tags on the instance, and `search_workflows({ tags: ['<tag>'] })` filters by tag name. Apply tags (e.g. by team, domain, or environment) so both humans and agents can discover sub-workflows reliably.
 - **Split when input contracts genuinely differ** (binary vs JSON, sync vs async, divergent auth schemes). Don't fit divergent contracts under one trigger via passthrough + internal branching. See `references/SUBWORKFLOW_PATTERNS.md` "Splitting by input shape".
 
 ## Decision tree: should this be a sub-workflow?
@@ -150,9 +149,10 @@ You're about to build something you've built before. Stop. Search.
 search_workflows({ query: 'date' })
 search_workflows({ query: 'Customer' })
 search_workflows({ query: 'Subworkflow:' })
+search_workflows({ tags: ['utilities'] })    // if your team uses tags for categorization
 ```
 
-If something matches, use it. If not, build it as a sub-workflow so the *next* search finds it. The prefix convention (`Subworkflow:`, `Customer:`, etc.) is what makes that work.
+If something matches, use it. If not, build it as a sub-workflow so the *next* search finds it. The prefix convention (`Subworkflow:`, `Customer:`, etc.) is what makes name-based search work. Tags complement this: apply them at create time so `search_workflows({ tags: [...] })` can filter by category.
 
 ## Linear, long workflows are fine when most of the work is in sub-workflows
 
@@ -199,6 +199,7 @@ When the user describes something multi-step or generic-sounding:
 
 ```
 1. search_workflows with relevant queries (e.g. 'Subworkflow', the domain prefix, the operation keyword)
+   OR search_workflows({ tags: ['<relevant-tag>'] }) if your team uses tags for categorization
 2. If candidates appear, fetch get_workflow_details on the top 1-3
 3. Confirm fit by reading the inputs/outputs and (briefly) the body
 4. If a fit exists → use it. Tell the user "I found `<name>`. Using that."
@@ -305,7 +306,7 @@ For the polling-after-fire-and-forget pattern, see `references/SUBWORKFLOW_PATTE
 | Anti-pattern | What goes wrong | Fix |
 |---|---|---|
 | Duplicating the same date-parsing nodes in three workflows | Bug fixes happen in two places, miss the third | Extract to `Subworkflow: Parse <format> date` once |
-| Building a new sub-workflow without searching | Library grows duplicates, and future searches find both | Always `search_workflows` first |
+| Building a new sub-workflow without searching | Library grows duplicates, and future searches find both | Always `search_workflows` first (by query and/or tags) |
 | Sub-workflow named/described as pure that quietly writes to a log table | Callers can't reason about retry or idempotency, side effect ambushes them | Either make the side effect part of the contract (rename, document, return its result) or move it out |
 | Sub-workflow with no `description` | Won't be found in future searches, nobody knows what it does | Set `description` with input/output shape and purpose |
 | Sub-workflow named `Helper 3` | Name doesn't tell anyone what it does, and doesn't match any prefix-based search | Verb-first prefix name (`Subworkflow: ...`, `Customer: ...`), see `n8n-workflow-lifecycle` `NAMING_CONVENTIONS.md` |
@@ -314,4 +315,3 @@ For the polling-after-fire-and-forget pattern, see `references/SUBWORKFLOW_PATTE
 | Passthrough trigger for a zero-input sub-workflow without a Set-to-clear node and explanatory sticky | Body silently reads stray fields from whatever the caller forwarded; future readers think passthrough is for binary | Add a `Set` ("Keep Only Set", no fields) at the top of the body and a sticky on the trigger noting no inputs are expected |
 | Sub-workflow called as an agent tool that expects binary input | Agent tools can't pass binary directly | See `n8n-binary-and-data` `AGENT_TOOL_BINARY.md` for the right pattern |
 | 30-node workflow with no extraction | Hard to read, hard to test, hard to replace | Extract logical sections into sub-workflows |
-

--- a/skills/n8n-workflow-lifecycle/SKILL.md
+++ b/skills/n8n-workflow-lifecycle/SKILL.md
@@ -72,7 +72,7 @@ For full conventions (verb-noun patterns, capitalization, prefixes), read `refer
 - **Workflows:** verb-first, scoped. `Send weekly customer report` not `Customer report sender`.
 - **Nodes:** describe what they *do* in this workflow, not the node type. `Fetch active customers` not `Postgres1`.
 - **Sub-workflows:** prefix with the domain or `Subworkflow:` for stateless reusable ones. `Subworkflow: Parse RFC2822 date`. The prefix is what `search_workflows({ query })` matches on. See `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
-- **Tags:** UI-only. The MCP can't read or write tags, so they're for humans browsing the UI. Don't rely on them for AI discovery.
+- **Tags:** useful for both UI browsing and MCP-based discovery. The MCP can list all tags via `list_tags` and filter workflows by tag name via `search_workflows({ tags: [...] })`. Use tags to categorize workflows (e.g. by team, environment, or domain) so both humans and agents can find them.
 
 ## Readability: descriptions, sticky notes, conventions
 
@@ -167,4 +167,3 @@ Keep it tight: half a dozen bullets, not a wall of text. The user shouldn't have
 | Sticky titled "Set, If, Set" or sticky-of-every-color | Re-states what's visible / color becomes pure noise | Title with the *purpose*; one color per category |
 | `description: "Sends Slack."` | Adds nothing visible from the trigger and Slack node | Include *why* + AI-derived context: "Sends weekly summary to founders. Replaces manual report that kept getting skipped." |
 | Designing fan-out branches as if they execute concurrently | n8n runs fan-out branches sequentially, top-to-bottom by Y-position. Total runtime is the sum of branches, not the max | For real concurrency, dispatch via `Execute Workflow` with `mode: 'each'` + `waitForSubWorkflow: false`. See `n8n-subworkflows` "Fire-and-forget parallelization" |
-

--- a/skills/using-n8n-skills/SKILL.md
+++ b/skills/using-n8n-skills/SKILL.md
@@ -82,12 +82,13 @@ Tool names are shown without the MCP prefix. The qualified name is `mcp__<server
 
 | Tool | What it does |
 |---|---|
-| `search_workflows` | Search workflows across the instance by `query` (matches name and description, but tags are not filterable via MCP). The **only** cross-workflow tool. Use it to discover what already exists. |
+| `search_workflows` | Search workflows across the instance by `query` (matches name and description) and/or `tags` (array of tag name strings, deduplicated, empty strings dropped). Results include a `tags` field (`[{ id, name }]`) on each workflow. |
 | `get_workflow_details` | Fetch a workflow's full JSON by ID. Use after every create/update to verify connections. |
 | `search_folders` | List folders. **You cannot create or move folders.** You can only place workflows into folders that already exist. |
 | `search_projects` | List projects. |
 | `archive_workflow` / `publish_workflow` / `unpublish_workflow` | Soft-delete / activate / deactivate. Validate before publish. |
 | `search_executions` | Search executions across the instance (filter by status, workflow, time range). Use for "list recent runs" / "failures in the last hour". Single executions: `get_execution`. |
+| `list_tags` | List all workflow tags on the instance with usage counts. Optional `limit` parameter (default 500). Returns `{ count, totalCount, data: [{ id, name, usageCount, createdAt, updatedAt }] }`. Read-only, idempotent. |
 
 ### Workflow building
 


### PR DESCRIPTION
## Summary

Syncs skill documentation with changes introduced in https://github.com/n8n-io/n8n/pull/31446.

### What changed in the MCP module

- **New tool `list_tags`**: lists all workflow tags on the instance with usage counts. Optional `limit` parameter (default 500). Returns `{ count, totalCount, data: [{ id, name, usageCount, createdAt, updatedAt }] }`. Read-only, idempotent, requires `tag:list` scope.
- **`search_workflows` extended**: now accepts a `tags` array filter (tag name strings, deduplicated, empty strings dropped) and returns a `tags: [{ id, name }]` field on each workflow result.

### Skill docs updated

1. **`skills/using-n8n-skills/SKILL.md`** — Updated `search_workflows` table entry to reflect the new `tags` filter and output field. Added `list_tags` to the Workflow management tools table.
2. **`skills/n8n-workflow-lifecycle/SKILL.md`** — Removed the incorrect claim that tags are UI-only and not MCP-accessible. Updated to reflect that `list_tags` and `search_workflows` tags filter are now available.
3. **`skills/n8n-subworkflows/SKILL.md`** — Resolved the `<!-- TEMPORARY -->` comment about switching to tags when tag tools are added to the MCP. Updated discovery guidance to recommend tags alongside prefix-based naming.
4. **`skills/n8n-extending-mcp/SKILL.md`** — Removed "list" from the tag CRUD capabilities listed as missing from the MCP, since `list_tags` now exists.