### PR TITLE
adopt n8n 2.27.0 MCP tag tools; make sub-workflow discovery tag-based

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "n8n-skills",
       "source": "./",
       "description": "Production-grade n8n workflow building skills for Claude Code. Pairs with the official n8n MCP server.",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "category": "automation",
       "tags": ["n8n", "workflow", "automation", "mcp"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-skills",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Production-grade n8n workflow building skills. Pairs with the official n8n instance-level MCP server to teach Claude how to architect, validate, and ship workflows that work in production.",
   "author": {
     "name": "n8n",

--- a/plugins/n8n-skills/.codex-plugin/plugin.json
+++ b/plugins/n8n-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-skills",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Production-grade n8n workflow building skills. Pairs with the official n8n instance-level MCP server to teach your coding agent how to architect, validate, and ship workflows that work in production.",
   "author": {
     "name": "n8n",

--- a/plugins/n8n-skills/skills/n8n-agents/references/SUBWORKFLOW_AS_TOOL.md
+++ b/plugins/n8n-skills/skills/n8n-agents/references/SUBWORKFLOW_AS_TOOL.md
@@ -97,7 +97,7 @@ Encapsulation: the sub-workflow can be refactored heavily without changing what 
 
 Goal: an agent that can generate or edit images. Both share most logic (prompt → Gemini → upload → return URL), but they differ in whether they download an existing image first.
 
-**Sub-workflow `Subworkflow: Generate or edit image`:**
+**Sub-workflow `Generate or edit image` (tags `subworkflow`, `tool`):**
 
 ```
 [Execute Workflow Trigger: { imagePrompt, imageName, sessionId }]
@@ -182,9 +182,7 @@ For the broader error story (4xx/5xx mapping, retries, error workflows, deciding
 
 ### Keep tool sub-workflows discoverable
 
-<!-- TEMPORARY: when tags are added, put here that tags should always be put on subworkflows -->
-
-Name them with the standard prefix (`Subworkflow:` or domain-specific). The Tool Workflow node references them by ID (stable), but humans browse the UI by name.
+Tag them with `tool` (plus a domain tag like `customer` where it applies) so `search_workflows({ tags: ['tool'] })` finds them. Attach tags with `update_workflow` `addTags` after creating, since `create_workflow_from_code` can't set tags. Give them a plain descriptive name; the Tool Workflow node references them by ID (stable), and tags carry the category.
 
 ### Wire `onError: 'continueErrorOutput'` on fallible nodes
 

--- a/plugins/n8n-skills/skills/n8n-extending-mcp/SKILL.md
+++ b/plugins/n8n-skills/skills/n8n-extending-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: n8n-extending-mcp
-description: 'Use when you want to expose an n8n workflow as a tool the coding agent can call. Two cases. (1) Wrap n8n API capabilities the MCP doesn''t natively expose: folder CRUD, tag CRUD, instance metadata, credential creation. (2) Expose a general-purpose workflow as an agent tool: a workflow that calls a third-party API, runs business logic, or does any task you want the agent to invoke. Triggers on "expose as MCP tool", "build a tool for my agent", "I need to know X" where X isn''t an MCP tool, "create folder", "create tag", or any capability gap.'
+description: 'Use when you want to expose an n8n workflow as a tool the coding agent can call. Two cases. (1) Wrap n8n API capabilities the MCP doesn''t natively expose: folder CRUD, tag rename/delete, instance metadata, credential creation. (2) Expose a general-purpose workflow as an agent tool: a workflow that calls a third-party API, runs business logic, or does any task you want the agent to invoke. Triggers on "expose as MCP tool", "build a tool for my agent", "I need to know X" where X isn''t an MCP tool, "create folder", "rename tag", or any capability gap.'
 ---
 
 <!-- TEMPORARY: update whenever n8n mcp capacities are added. a lot of listed functionalities missing are coming soon -->
@@ -8,7 +8,7 @@ description: 'Use when you want to expose an n8n workflow as a tool the coding a
 
 Any n8n workflow with MCP access enabled becomes a tool the coding agent can call by name. Two common cases:
 
-1. **Wrap n8n capabilities the MCP doesn't expose.** The MCP covers workflow CRUD, validation, execution, data tables, credential listing, execution search, folder/project listing. Still missing: folder CRUD, tag CRUD, instance metadata, credential creation. Build a workflow that hits the n8n API and exposes the result as an agent tool.
+1. **Wrap n8n capabilities the MCP doesn't expose.** The MCP covers workflow CRUD, validation, execution, data tables, credential listing, execution search, folder/project listing, tag listing and attach/detach. Still missing: folder CRUD, tag rename/delete, instance metadata, credential creation. Build a workflow that hits the n8n API and exposes the result as an agent tool.
 2. **Expose a general-purpose workflow as a tool.** A workflow that has nothing to do with n8n itself (calls a third-party API, runs internal business logic, looks something up in a private system) can be MCP-callable. Lets the agent invoke real operations during a coding session.
 
 The MCP calls your workflow as if it were a native tool: input from the `Execute Workflow Trigger`, output from the workflow's last node.
@@ -18,7 +18,7 @@ The MCP calls your workflow as if it were a native tool: input from the `Execute
 Case 1 (wrap n8n capability):
 
 - Folder CRUD (create, rename, move, delete): REST API exists, no MCP tool yet.
-- Tag CRUD (create, list, get, delete): REST API exists, no MCP tool yet.
+- Tag rename/delete: the MCP lists tags (`list_tags`) and attaches/detaches them (`update_workflow` `addTags`/`removeTags`, auto-creating unknown names), but can't rename or delete tag entities. REST API exists for those.
 - Instance metadata (limits, plan info, configured integrations): no MCP tool.
 - Credential creation: REST API exists (`POST /credentials`), no MCP tool yet.
 - Any n8n API operation the MCP doesn't natively expose.
@@ -41,7 +41,7 @@ Don't reach for this for:
 
 ## Protocol
 
-- **Search for existing wrappers first.** `search_workflows({ query: 'Tool:' })` and a capability keyword search. If something matches, use it instead of duplicating.
+- **Search for existing wrappers first.** `search_workflows({ tags: ['tool'] })` and a capability keyword search. If something matches, use it instead of duplicating.
 - **For case 1, build as a stateless, queryable utility.** Takes input, calls n8n's API, returns the result. No side effects. Case 2 may legitimately have side effects (sending, writing); name them in the tool description.
 - **Offer to edit the agent's context file yourself** (CLAUDE.md, AGENTS.md, GEMINI.md, whatever the user's agent reads on session start) to add an entry for the new tool. You have Edit/Write tools, so there's no reason to make the user paste a snippet manually. Ask first since it's their config file, then edit it directly when they say yes.
 

--- a/plugins/n8n-skills/skills/n8n-subworkflows/SKILL.md
+++ b/plugins/n8n-skills/skills/n8n-subworkflows/SKILL.md
@@ -3,8 +3,6 @@ name: n8n-subworkflows
 description: Use when building anything multi-step, anything that looks repeatable, anything the user mentions reusing, or any workflow with more than ~10 nodes. Triggers on "reuse", "I do this in another workflow", "extract", "modular", "shared logic", "subworkflow", multi-step builds, or any task that mentions logic the user has built before.
 ---
 
-<!-- TEMPORARY: change workflow prefix searching to tags when tag tools are added to mcp -->
-
 # n8n Sub-workflows
 
 Sub-workflows are reusable functions. The `Execute Workflow Trigger` declares input parameters, the body does work, the last node returns output. Callers invoke it like any other node.
@@ -15,14 +13,14 @@ Without sub-workflows, the same logic gets duplicated across workflows. Bug fixe
 
 ## Non-negotiables
 
-1. **Search before you build.** Before writing logic that handles a generic problem, check if a sub-workflow already exists. Use `search_workflows({ query: 'Subworkflow' })`, `query: '<keyword>'`, etc. The MCP can't filter by tags, so naming is the discovery mechanism.
+1. **Search before you build.** Before writing logic that handles a generic problem, check if a sub-workflow already exists. Filter by tag (`search_workflows({ tags: ['subworkflow'] })`, a domain tag) and/or keyword (`query: '<keyword>'`). Tags are the discovery mechanism (n8n 2.27.0+).
 2. **`Execute Workflow Trigger` uses "Define Below" with typed fields, not passthrough.** Define Below is the only mode that lets agent tools (`fromAi`) and structured callers pass values in. Two exceptions: (a) the sub-workflow specifically needs to receive binary (then it can't be wired as an agent tool directly), or (b) the sub-workflow takes no inputs at all (Define Below requires at least one field). See "Sub-workflow inputs and outputs" below.
 
 ## Strong defaults
 
 - **Anything reusable becomes a sub-workflow.** If a logical chunk could plausibly be needed elsewhere, extract it. Exception: trivial wrappers (one HTTP call, no logic) and tightly-coupled-to-this-caller chunks.
 - **Default to stateless for pure logic** (input → output, no external state). For state-touching logic, build *deliberately* stateful sub-workflows that abstract the operation behind a clean contract (the ORM / repository pattern). What to avoid is *accidental* state: a "validate" sub-workflow that quietly writes to a log table.
-- **Verb-first prefix naming**: `Subworkflow: Parse RFC2822 date`, `Customer: hydrate from Stripe`, `Tool: list available credentials`. The prefix is what `search_workflows` matches on. See `references/NAMING_AND_DISCOVERY.md`.
+- **Tag for discovery**: every sub-workflow gets `subworkflow`, a domain tag (`customer`), and/or `tool`. Tags are what `search_workflows({ tags })` filters on; names stay plain and descriptive (`Parse RFC2822 date`). See `references/NAMING_AND_DISCOVERY.md`.
 - **Description carries keywords.** Input/output shape + representative terms, so varied queries surface it.
 - **Split when input contracts genuinely differ** (binary vs JSON, sync vs async, divergent auth schemes). Don't fit divergent contracts under one trigger via passthrough + internal branching. See `references/SUBWORKFLOW_PATTERNS.md` "Splitting by input shape".
 
@@ -54,9 +52,9 @@ Takes input, returns output. No I/O outside the inputs/outputs. Default for pure
 
 Examples:
 
-- `Subworkflow: Parse RFC2822 date`. Input: date string. Output: ISO date or error.
-- `Subworkflow: Compute MRR from subscription`. Input: subscription object. Output: MRR number.
-- `Subworkflow: Format invoice as HTML`. Input: invoice data. Output: HTML string.
+- `Parse RFC2822 date` (tag `subworkflow`). Input: date string. Output: ISO date or error.
+- `Compute MRR from subscription` (tag `subworkflow`). Input: subscription object. Output: MRR number.
+- `Format invoice as HTML` (tag `subworkflow`). Input: invoice data. Output: HTML string.
 
 When you need the logic again, call it without worrying about side effects firing.
 
@@ -66,10 +64,10 @@ Reads or writes external state behind a clean input/output contract. Comparable 
 
 Examples:
 
-- `Customer: get by id`. Input: id. Output: customer object or `{ ok: false, error: 'not_found' }`. Reads the DB.
-- `Customer: write billing record`. Input: record. Output: `{ ok: true, id }`. Writes the DB.
-- `Audit: append event`. Input: event. Output: `{ ok: true, eventId }`. Writes to a logging store.
-- `Notify: send to on-call`. Input: channel, message. Output: `{ ok: true, messageId }`. Calls Slack/SMTP.
+- `Get customer by id` (tag `customer`). Input: id. Output: customer object or `{ ok: false, error: 'not_found' }`. Reads the DB.
+- `Write customer billing record` (tags `customer`, `billing`). Input: record. Output: `{ ok: true, id }`. Writes the DB.
+- `Append audit event` (tag `audit`). Input: event. Output: `{ ok: true, eventId }`. Writes to a logging store.
+- `Send to on-call` (tag `notification`). Input: channel, message. Output: `{ ok: true, messageId }`. Calls Slack/SMTP.
 
 The point of building these as sub-workflows:
 
@@ -128,15 +126,15 @@ When a webhook workflow is API-shaped, treat it like one. Sub-workflows become m
 
 ```
 Webhook
-  → [Subworkflow: Verify JWT]    # decode + validate; 401 on failure
-  → [Subworkflow: Rate limit]    # check + bump counter; 429 on failure
+  → [Verify JWT]    # decode + validate; 401 on failure
+  → [Rate limit]    # check + bump counter; 429 on failure
   → IF (all middleware ok)
     → Main handler logic
     → Respond 200
   → ELSE → Respond with the 4xx the middleware returned
 ```
 
-Canonical example: custom JWT auth rolled inside n8n. `Subworkflow: Verify JWT` takes the raw `Authorization` header, decodes, validates signature and expiry, returns `{ ok: true, user_id }` or `{ ok: false, status: 401, message }`. The caller IFs on `ok`, responds early on failure, continues on success.
+Canonical example: custom JWT auth rolled inside n8n. `Verify JWT` (tag `subworkflow`) takes the raw `Authorization` header, decodes, validates signature and expiry, returns `{ ok: true, user_id }` or `{ ok: false, status: 401, message }`. The caller IFs on `ok`, responds early on failure, continues on success.
 
 Why a sub-workflow and not inline: every webhook that needs auth calls the same one. Swap the library, rotate the signing key, or add refresh-token logic in a single place. The reuse target is exact, the contract is small, and the failure response shape is consistent across every API endpoint.
 
@@ -148,11 +146,11 @@ You're about to build something you've built before. Stop. Search.
 
 ```
 search_workflows({ query: 'date' })
-search_workflows({ query: 'Customer' })
-search_workflows({ query: 'Subworkflow:' })
+search_workflows({ tags: ['customer'] })
+search_workflows({ tags: ['subworkflow'] })
 ```
 
-If something matches, use it. If not, build it as a sub-workflow so the *next* search finds it. The prefix convention (`Subworkflow:`, `Customer:`, etc.) is what makes that work.
+If something matches, use it. If not, build it as a sub-workflow and tag it so the *next* search finds it. The tag convention (`subworkflow`, domain tags, `tool`) is what makes that work.
 
 ## Linear, long workflows are fine when most of the work is in sub-workflows
 
@@ -198,11 +196,11 @@ If your workflow has 15+ nodes and isn't mostly Execute Workflow calls and branc
 When the user describes something multi-step or generic-sounding:
 
 ```
-1. search_workflows with relevant queries (e.g. 'Subworkflow', the domain prefix, the operation keyword)
+1. search_workflows with relevant tags and/or query (e.g. `tags: ['subworkflow']`, a domain tag, the operation keyword)
 2. If candidates appear, fetch get_workflow_details on the top 1-3
 3. Confirm fit by reading the inputs/outputs and (briefly) the body
 4. If a fit exists → use it. Tell the user "I found `<name>`. Using that."
-5. If no fit exists → build new with the prefix convention so the next search finds it
+5. If no fit exists → build new and tag it (`subworkflow`, domain, `tool`) so the next search finds it
 ```
 
 The "tell the user" step matters. They benefit from knowing what's already in their library.
@@ -298,18 +296,18 @@ For the polling-after-fire-and-forget pattern, see `references/SUBWORKFLOW_PATTE
 | File | Read when |
 |---|---|
 | `references/SUBWORKFLOW_PATTERNS.md` | `mode: 'all'` vs `'each'` default, splitting by input shape (binary/passthrough vs Define Below), fire-and-forget parallelization with Data Table polling |
-| `references/NAMING_AND_DISCOVERY.md` | Naming a new sub-workflow, searching for existing ones, the prefix convention |
+| `references/NAMING_AND_DISCOVERY.md` | Naming and tagging a new sub-workflow, searching for existing ones, the tag convention |
 
 ## Anti-patterns
 
 | Anti-pattern | What goes wrong | Fix |
 |---|---|---|
-| Duplicating the same date-parsing nodes in three workflows | Bug fixes happen in two places, miss the third | Extract to `Subworkflow: Parse <format> date` once |
+| Duplicating the same date-parsing nodes in three workflows | Bug fixes happen in two places, miss the third | Extract to a single `Parse <format> date` sub-workflow (tag `subworkflow`) once |
 | Building a new sub-workflow without searching | Library grows duplicates, and future searches find both | Always `search_workflows` first |
 | Sub-workflow named/described as pure that quietly writes to a log table | Callers can't reason about retry or idempotency, side effect ambushes them | Either make the side effect part of the contract (rename, document, return its result) or move it out |
 | Sub-workflow with no `description` | Won't be found in future searches, nobody knows what it does | Set `description` with input/output shape and purpose |
-| Sub-workflow named `Helper 3` | Name doesn't tell anyone what it does, and doesn't match any prefix-based search | Verb-first prefix name (`Subworkflow: ...`, `Customer: ...`), see `n8n-workflow-lifecycle` `NAMING_CONVENTIONS.md` |
-| Sub-workflow with no `Subworkflow:` / domain prefix | Won't show up under `query: 'Subworkflow'` or domain searches, future you can't find it | Always use a prefix at create time |
+| Sub-workflow named `Helper 3` | Name doesn't tell anyone what it does | Verb-first descriptive name (`Parse RFC2822 date`), see `n8n-workflow-lifecycle` `NAMING_CONVENTIONS.md` |
+| Untagged sub-workflow | Won't show up under any `tags` filter, future you can't find it | Tag it (`subworkflow`, domain, `tool`) right after create via `update_workflow` `addTags` |
 | `Execute Workflow Trigger` set to `passthrough` when not handling binary and not deliberately zero-input | No typed schema means agent tools can't fill parameters via `fromAi`, structured callers can't pass values cleanly | Use "Define Below" with declared `workflowInputs.values` (name + type per field). The exceptions are binary-receiving sub-workflows and sub-workflows that genuinely take no inputs (see "Exception 2") |
 | Passthrough trigger for a zero-input sub-workflow without a Set-to-clear node and explanatory sticky | Body silently reads stray fields from whatever the caller forwarded; future readers think passthrough is for binary | Add a `Set` ("Keep Only Set", no fields) at the top of the body and a sticky on the trigger noting no inputs are expected |
 | Sub-workflow called as an agent tool that expects binary input | Agent tools can't pass binary directly | See `n8n-binary-and-data` `AGENT_TOOL_BINARY.md` for the right pattern |

--- a/plugins/n8n-skills/skills/n8n-subworkflows/references/NAMING_AND_DISCOVERY.md
+++ b/plugins/n8n-skills/skills/n8n-subworkflows/references/NAMING_AND_DISCOVERY.md
@@ -1,57 +1,42 @@
-<!-- TEMPORARY: change workflow prefix searching to tags when tag tools are added to mcp -->
-
 # Naming and discovery
 
-A sub-workflow nobody can find gets duplicated. The MCP's only searchable surface is `search_workflows({ query })`, which matches against name and description. **That's the discovery mechanism.** Put discovery hooks in the name and description.
+A sub-workflow nobody can find gets duplicated. Discovery runs on two `search_workflows` surfaces: `tags` (exact-match category filter, AND semantics) and `query` (substring over name and description). **Tags are the primary category mechanism**; the query is keyword search within or across categories.
 
-## Tags don't help here
+## Tags are the discovery mechanism
 
-n8n has tags, but the MCP can't read, write, or filter by them. UI-only concept. Don't rely on tags for AI-side discovery.
+Requires n8n 2.27.0+. Tag every sub-workflow so future searches find it by category:
 
-## The naming convention IS the discovery mechanism
+| Tag | Use for |
+|---|---|
+| `subworkflow` | Stateless generic reusable building block |
+| `<domain>` (`customer`, `billing`, `notification`) | Domain-specific sub-workflow |
+| `tool` | MCP-callable tool (see `n8n-extending-mcp`) |
 
-Verb-first prefix names from `n8n-workflow-lifecycle`'s `NAMING_CONVENTIONS.md`:
+Tags compose, so a customer-domain tool carries `customer` + `tool`. How they drive `search_workflows`:
 
-```
-Subworkflow: <verb> <object>            # Stateless generic sub-workflow
-<Domain>: <verb> <object>        # Domain-specific
-Tool: <description>              # MCP-callable tool
-```
+- `{ tags: ['subworkflow'] }` returns every reusable sub-workflow.
+- `{ tags: ['customer'] }` returns every customer-domain workflow.
+- `{ tags: ['tool'] }` returns every MCP-callable tool.
+- `{ tags: ['customer', 'tool'] }` returns customer-domain tools only (AND: must have both).
+- `{ query: 'date' }` returns anything with "date" in name or description, regardless of tag.
+- `{ tags: ['subworkflow'], query: 'parse' }` narrows to parsing sub-workflows.
 
-Examples:
-
-- `Subworkflow: Parse RFC2822 date`
-- `Subworkflow: Compute MRR from subscription`
-- `Subworkflow: Format invoice as HTML`
-- `Customer: hydrate from Stripe`
-- `Customer: write to billing table`
-- `Billing: compute MRR`
-- `Notification: send + log`
-- `Tool: list available credentials`
-
-Why this works for `search_workflows({ query })`:
-
-- `query: 'Subworkflow:'` returns every reusable sub-workflow.
-- `query: 'Customer:'` returns every customer-domain sub-workflow.
-- `query: 'Tool:'` returns every MCP-callable tool.
-- `query: 'date'` returns anything with "date" in name or description, regardless of prefix.
-
-Use the prefix on every sub-workflow.
+`list_tags` shows the instance's existing tag vocabulary. Check it before inventing a tag so you reuse exact names: AND-filtering and `addTags` are case- and spelling-exact, so `customer` and `Customers` are two different tags.
 
 ## Search-before-build, in detail
 
 Before writing logic for a generic problem:
 
 ```
-search_workflows({ query: 'Subworkflow' })                  # all sub-workflows
-search_workflows({ query: 'date' })                  # anything date-related
-search_workflows({ query: 'Customer' })              # customer-domain
-search_workflows({ query: 'Subworkflow: Parse' })           # specific shape
+search_workflows({ tags: ['subworkflow'] })                 # all sub-workflows
+search_workflows({ query: 'date' })                         # anything date-related
+search_workflows({ tags: ['customer'] })                    # customer-domain
+search_workflows({ tags: ['subworkflow'], query: 'parse' }) # specific shape
 ```
 
-When to search: any time you're about to build something that fits a domain or operation keyword. About to parse a date? Query `date`. Format an invoice? Query `invoice`. Send a Slack notification? Query `Slack` and `Notification`.
+When to search: any time you're about to build something that fits a domain or operation keyword. About to parse a date? Query `date`. Format an invoice? Query `invoice`. Send a Slack notification? Query `Slack` or filter `tags: ['notification']`.
 
-Two queries is fine, and the cost is low. Better to over-search than duplicate.
+Two searches is fine, and the cost is low. Better to over-search than duplicate.
 
 If a candidate matches, fetch `get_workflow_details` and read the `description`. If inputs/outputs fit, use it. If close-but-not-quite, decide whether to extend the existing one or build a variant.
 
@@ -74,19 +59,24 @@ This tells the reader: what it does, the output shape, and the typical use case.
 
 Description also feeds `search_workflows` matching. Include representative keywords (e.g., "RFC2822", "date", "ISO", "webhook") so varied queries surface it.
 
-## Naming at create time
+## Naming and tagging at create time
 
-Set the name correctly when calling `create_workflow_from_code`:
+`create_workflow_from_code` sets name and description but **can't set tags**, so tag in a follow-up `update_workflow`:
 
 ```ts
 create_workflow_from_code({
-    name: 'Subworkflow: Parse RFC2822 date',
+    name: 'Parse RFC2822 date',
     description: 'Parses an RFC2822-formatted date string into ISO format. ...',
     code: '...',
 })
+// then, on the returned workflow id:
+update_workflow({
+    workflowId,
+    operations: [{ type: 'addTags', names: ['subworkflow'] }],
+})
 ```
 
-Easier than retrofitting. Don't let new sub-workflows ship without the prefix convention.
+`addTags` auto-creates `subworkflow` if the instance doesn't have it yet (needs the `tag:create` permission; without it, addTags errors on unknown names, so create the tag in the UI first). Don't let new sub-workflows ship untagged: an untagged one won't surface under any `tags` filter.
 
 ## Cross-project sub-workflows
 
@@ -97,7 +87,7 @@ Only share cross-project when both apply:
 - **Stateless**: no project-scoped credentials, data tables, or other state that wouldn't make sense outside the owning project.
 - **Generic problem**: date parsing, ID generation, signature validation, formatting. Things that are clearly not coupled to one project's domain.
 
-A stateful sub-workflow (`Customer: get by id`) shared across projects pulls one project's data into another's workflows, which is almost never what's intended. Keep those in-project, and let each project own its repository layer.
+A stateful sub-workflow (`Get customer by id`, tag `customer`) shared across projects pulls one project's data into another's workflows, which is almost never what's intended. Keep those in-project, and let each project own its repository layer.
 
 For cross-project sub-workflows that meet the bar:
 
@@ -108,31 +98,32 @@ For cross-project sub-workflows that meet the bar:
 
 Roughly:
 
-- 5 to 20 `Subworkflow:` sub-workflows for common shapes (date parsing, ID generation, formatting, etc.).
-- A handful of domain sub-workflows per main domain (`Customer:`, `Billing:`, `Notification:`).
+- 5 to 20 `subworkflow`-tagged sub-workflows for common shapes (date parsing, ID generation, formatting, etc.).
+- A handful per main domain tag (`customer`, `billing`, `notification`).
 - Fewer per-domain "operations" sub-workflows (write to billing table, send email + log).
 
 Counter-examples:
 
 - 100 sub-workflows: likely lots of near-duplicates to merge.
 - 0 sub-workflows: no extraction, logic is being duplicated.
-- 50 sub-workflows named `Helper`, `Util1`, `Helper2`: discoverability broken. Rename.
+- 50 sub-workflows named `Helper`, `Util1`, `Helper2` and untagged: discoverability broken. Rename and tag.
 
 ## When the user asks "what sub-workflows do we have?"
 
-Run a name-prefix search:
+Filter by tag:
 
 ```
-search_workflows({ query: 'Subworkflow:' })
+search_workflows({ tags: ['subworkflow'] })
 ```
 
-Return a list with name + 1-line summary from each `description`. Good moment to spot duplicates and propose consolidating.
+Return a list with name + 1-line summary from each `description`. Good moment to spot duplicates and propose consolidating. `list_tags` (which returns `usageCount` per tag) also gives a fast read on how the library is categorized.
 
 ## Renaming and reorganizing
 
 For duplicates or poorly-named sub-workflows:
 
 - Renaming preserves the workflow ID, so existing `Execute Workflow` callers still work. Search picks up the new name immediately.
+- Re-categorize with `update_workflow` `addTags`/`removeTags` (e.g. drop `subworkflow`, add `tool`). Tag changes don't touch the workflow ID either.
 - n8n has no alias mechanism. Just rename, update any sticky-note references, move on.
 
 For mass renames, audit callers via `search_workflows` and inspect each result's `Execute Workflow` references for the old workflow ID.

--- a/plugins/n8n-skills/skills/n8n-subworkflows/references/SUBWORKFLOW_PATTERNS.md
+++ b/plugins/n8n-skills/skills/n8n-subworkflows/references/SUBWORKFLOW_PATTERNS.md
@@ -50,19 +50,19 @@ Each outer sub-workflow does its input-specific prep (validation, fetching, norm
 A "process this paper" capability that can come from either an external ID or a user-uploaded PDF:
 
 ```
-Subworkflow: Process Paper from External ID
+Process Paper from External ID            (tag subworkflow)
   Trigger: Define Below { arxivId: string, source: string }
     → [Validate ID, dedup, fetch metadata, download PDF, extract text]
-    → [Execute Workflow: Subworkflow: Summarize and Store Paper]
+    → [Execute Workflow: Summarize and Store Paper]
         with { arxivId, title, authors, body, source, ... }
 
-Subworkflow: Process Paper from Uploaded PDF
+Process Paper from Uploaded PDF           (tag subworkflow)
   Trigger: Passthrough  (required: binary flows through)
     → [Hash binary for synthetic ID, dedup, extract text]
-    → [Execute Workflow: Subworkflow: Summarize and Store Paper]
+    → [Execute Workflow: Summarize and Store Paper]
         with { arxivId: '<synthetic>', title, body, source: 'upload', ... }
 
-Subworkflow: Summarize and Store Paper          (the shared core)
+Summarize and Store Paper                 (the shared core, tag subworkflow)
   Trigger: Define Below { arxivId, title, body, source, ... }
     → [LLM with structured output, Data Table Insert, return result]
 ```

--- a/plugins/n8n-skills/skills/n8n-workflow-lifecycle/SKILL.md
+++ b/plugins/n8n-skills/skills/n8n-workflow-lifecycle/SKILL.md
@@ -71,8 +71,8 @@ For full conventions (verb-noun patterns, capitalization, prefixes), read `refer
 
 - **Workflows:** verb-first, scoped. `Send weekly customer report` not `Customer report sender`.
 - **Nodes:** describe what they *do* in this workflow, not the node type. `Fetch active customers` not `Postgres1`.
-- **Sub-workflows:** prefix with the domain or `Subworkflow:` for stateless reusable ones. `Subworkflow: Parse RFC2822 date`. The prefix is what `search_workflows({ query })` matches on. See `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
-- **Tags:** UI-only. The MCP can't read or write tags, so they're for humans browsing the UI. Don't rely on them for AI discovery.
+- **Sub-workflows:** plain descriptive name (`Parse RFC2822 date`); carry the category in tags (`subworkflow`, a domain tag, `tool`), not a name prefix. `search_workflows({ tags })` filters on them. See `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
+- **Tags:** the AI-side discovery mechanism (n8n 2.27.0+). The MCP lists (`list_tags`), filters (`search_workflows({ tags })`), and attaches them (`update_workflow` `addTags`/`removeTags`, auto-creating unknown names). Lowercase, 2-4 per workflow. See `references/NAMING_CONVENTIONS.md`.
 
 ## Readability: descriptions, sticky notes, conventions
 

--- a/plugins/n8n-skills/skills/n8n-workflow-lifecycle/references/NAMING_CONVENTIONS.md
+++ b/plugins/n8n-skills/skills/n8n-workflow-lifecycle/references/NAMING_CONVENTIONS.md
@@ -25,21 +25,23 @@ Sentence case, not Title Case. Easier to scan, and matches normal prose. Acronym
 
 ### Punctuation
 
-- Colon for category prefix: `Subworkflow: Parse RFC2822 date`, `Daily: clean up stale Slack DMs`.
+- Colon for category prefix on top-level workflows: `Daily: clean up stale Slack DMs`, `Webhook: report-request`. Sub-workflows categorize by tag, not name prefix (see Sub-workflows and Tags below).
 - No emojis in workflow names. They break in URLs, search, and CLI tools.
 - No trailing version numbers (`v2`, `final`). For versioning, archive the old one or use git on the SDK code.
 
 ## Sub-workflows
 
-Same verb-first rule, but prefix with a domain or `Subworkflow:` for stateless sub-workflows reusable anywhere.
+Same verb-first rule. The name says what the sub-workflow does; a **tag** says what kind it is. Category lives in tags, not a name prefix.
 
-| Pattern | Example |
+| Name | Tags |
 |---|---|
-| `Subworkflow: <verb> <object>` | `Subworkflow: Fetch JSON with retry`, `Subworkflow: Parse RFC2822 date` |
-| `<Domain>: <verb> <object>` | `Customer: hydrate from Stripe`, `Billing: compute MRR` |
-| `Tool: <description>` | `Tool: list available credentials` (for MCP-extending workflows, see `n8n-extending-mcp`) |
+| `Fetch JSON with retry` | `subworkflow` |
+| `Parse RFC2822 date` | `subworkflow` |
+| `Hydrate customer from Stripe` | `customer`, `subworkflow` |
+| `Compute MRR` | `billing` |
+| `List available credentials` | `tool` (MCP-extending workflows, see `n8n-extending-mcp`) |
 
-The prefix isn't a folder, it's a name pattern. It exists as a workaround: the MCP currently doesn't expose tags, and `search_workflows` matches only against name and description, so prefixes act as the searchable category mechanism. If/when the MCP adds tag support, this convention should shift from prefix-based to tag-based; the prefix is a temporary stand-in for what tags will eventually do better.
+Tags compose: a customer-domain tool carries `customer` + `tool`. `search_workflows({ tags })` filters on them with AND semantics (a workflow must have every listed tag). This replaces the old name-prefix convention, which only existed because the MCP couldn't filter by tags. Full discovery protocol: `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
 
 ## Nodes
 
@@ -69,22 +71,18 @@ For `Merge`, name after what's being merged (`Merge customer + Stripe data`).
 
 ## Tags
 
-Tags are UI-only. The n8n MCP cannot create, attach, read, or filter by tags, and the SDK doesn't expose a tags field. Useful for **humans** browsing the UI, but **not** an AI discovery mechanism.
+Tags are the AI-side discovery and categorization mechanism (n8n 2.27.0+). The MCP can read them (`list_tags`), filter by them (`search_workflows({ tags })`, AND semantics), and attach/detach them (`update_workflow` `addTags`/`removeTags`). `addTags` auto-creates an unknown tag, so you never pre-register one. It cannot rename or delete tag entities, and `create_workflow_from_code` can't set tags at create time, so tag right after creating.
 
-If tagging in the UI:
+Tag names are now exact-match machine identifiers, not just human labels:
 
-- All lowercase, with spaces (not hyphens): `customer data`, `daily report`, `util`, `prod`.
-- Optionally lead with an emoji as a quick visual category marker: `🧰 util`, `📊 daily report`, `💵 financial`. Use it consistently within a project or skip it entirely. Mixing tagged-with-emoji and tagged-without-emoji within the same project defeats the purpose.
-- Aim for up to 2-4 per workflow, since more can be noise.
+- All lowercase, spaces not hyphens: `customer`, `daily report`, `util`, `prod`. A case or spelling mismatch is a different tag.
+- No emojis. `addTags` and the `tags` filter match names exactly, so an emoji makes every match fragile.
+- **`list_tags` before tagging** to reuse the instance's existing names instead of spawning near-duplicates (`customer` vs `customers`).
+- Aim for 2-4 per workflow. More is noise.
 
-### Discovery is name-based, not tag-based
+Standard category tags: `subworkflow` (reusable building block), a domain tag (`customer`, `billing`, `notification`), and `tool` (MCP-callable, see `n8n-extending-mcp`). For the full discovery protocol, see `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
 
-`search_workflows({ query })` matches name and description only. To make a sub-workflow findable, the name must contain the discovery hook:
-
-- Verb-first prefix: `Subworkflow: Parse RFC2822 date`, `Customer: hydrate from Stripe`, `Tool: list available credentials`.
-- Description carries representative keywords.
-
-For the full naming-and-discovery protocol, see `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
+Instance and user conventions overrule all of the above. If `list_tags` shows an existing vocabulary, or the user prefers different names, casing, or categories, match theirs. Consistency within an instance beats this skill's defaults.
 
 ## Workflow `description`
 

--- a/plugins/n8n-skills/skills/n8n-workflow-lifecycle/references/REVIEW_CHECKLIST.md
+++ b/plugins/n8n-skills/skills/n8n-workflow-lifecycle/references/REVIEW_CHECKLIST.md
@@ -235,7 +235,7 @@ The system prompt is the load-bearing config of an agent. Severity ranges by how
 ### Naming
 
 - [ ] **Workflow name doesn't follow verb-first pattern** (`Send weekly customer report` vs. `Customer report sender`). → [NAMING_CONVENTIONS.md](NAMING_CONVENTIONS.md)
-- [ ] **Sub-workflow without a discoverable prefix** (`Subworkflow:`, `<Domain>:`, `Tool:`). The MCP can't filter by tags; naming is the discovery mechanism. → [NAMING_AND_DISCOVERY.md](../../n8n-subworkflows/references/NAMING_AND_DISCOVERY.md)
+- [ ] **Untagged sub-workflow** (missing `subworkflow`, a domain tag, or `tool`). Tags are the discovery mechanism; an untagged sub-workflow won't surface under any `tags` filter. → [NAMING_AND_DISCOVERY.md](../../n8n-subworkflows/references/NAMING_AND_DISCOVERY.md)
 
 ### Readability
 

--- a/plugins/n8n-skills/skills/n8n-workflow-lifecycle/references/VALIDATION_CHECKLIST.md
+++ b/plugins/n8n-skills/skills/n8n-workflow-lifecycle/references/VALIDATION_CHECKLIST.md
@@ -88,7 +88,7 @@ Fix and re-test if anything's off.
 
 Quick pass:
 
-- Workflow name follows the verb-first pattern (`NAMING_CONVENTIONS.md`). Sub-workflows use a prefix (`Subworkflow:`, `<Domain>:`, `Tool:`) since that's how `search_workflows` finds them.
+- Workflow name follows the verb-first pattern (`NAMING_CONVENTIONS.md`). Sub-workflows are tagged (`subworkflow`, a domain tag, `tool`) since that's how `search_workflows({ tags })` finds them.
 - `description` is set and captures both *what* and *why*, with searchable keywords.
 - Nodes are renamed from defaults.
 

--- a/plugins/n8n-skills/skills/using-n8n-skills/SKILL.md
+++ b/plugins/n8n-skills/skills/using-n8n-skills/SKILL.md
@@ -26,7 +26,7 @@ Unless a user preference overrides it, err on the side of loading too many skill
 ## Strong defaults (each skill owns its exceptions)
 
 - **The Code node is a last resort.** Expression first, then arrow function inside Edit Fields, then Code. Code earns its place for multi-source aggregation, libraries, and stateful work. See `n8n-code-nodes`.
-- **Anything reusable becomes a stateless sub-workflow.** Search existing ones via `search_workflows({ query: 'Subworkflow' })` before building. See `n8n-subworkflows`.
+- **Anything reusable becomes a stateless sub-workflow.** Search existing ones via `search_workflows({ tags: ['subworkflow'] })` before building. See `n8n-subworkflows`.
 
 ## Red flags: thoughts that mean STOP and invoke
 
@@ -59,7 +59,7 @@ Invoke via the Skill tool. Trigger column = when to invoke.
 | Skill | Trigger |
 |---|---|
 | `n8n-workflow-lifecycle` | Starting, designing, organizing, or finishing a workflow. Covers sticky-note conventions, descriptions that capture the *why*, naming, validation checklist, folder limitations, MCP-access-per-workflow gotcha |
-| `n8n-subworkflows` | Anything reusable, multi-step builds, or the user mentions reuse. Search before building, stateless patterns, naming-prefix convention for discovery |
+| `n8n-subworkflows` | Anything reusable, multi-step builds, or the user mentions reuse. Search before building, stateless patterns, tag-based discovery convention |
 | `n8n-extending-mcp` | You need capabilities the MCP doesn't natively provide. Wrap n8n APIs as workflow tools, with user permission |
 | `n8n-expressions` | Writing `{{}}`, `$json`, `$node`, expression errors. Luxon for dates, indented multi-line, prefer expressions over extra nodes |
 | `n8n-node-configuration` | Configuring any node. Operation-aware, property dependencies, never assume parameters |
@@ -82,10 +82,11 @@ Tool names are shown without the MCP prefix. The qualified name is `mcp__<server
 
 | Tool | What it does |
 |---|---|
-| `search_workflows` | Search workflows across the instance by `query` (matches name and description, but tags are not filterable via MCP). The **only** cross-workflow tool. Use it to discover what already exists. |
+| `search_workflows` | Search workflows across the instance by `query` (substring on name/description) and/or `tags` (exact tag names, AND semantics: must have all). The **only** cross-workflow tool. Use it to discover what already exists. |
 | `get_workflow_details` | Fetch a workflow's full JSON by ID. Use after every create/update to verify connections. |
 | `search_folders` | List folders. **You cannot create or move folders.** You can only place workflows into folders that already exist. |
 | `search_projects` | List projects. |
+| `list_tags` | List all workflow tags (with `usageCount` per tag). Check the instance's tag vocabulary before tagging or filtering, so you reuse exact names. Tags are attached/detached via `update_workflow` `addTags`/`removeTags`; there's no tag rename/delete tool. |
 | `archive_workflow` / `publish_workflow` / `unpublish_workflow` | Soft-delete / activate / deactivate. Validate before publish. |
 | `search_executions` | Search executions across the instance (filter by status, workflow, time range). Use for "list recent runs" / "failures in the last hour". Single executions: `get_execution`. |
 
@@ -98,7 +99,7 @@ Tool names are shown without the MCP prefix. The qualified name is `mcp__<server
 | `search_nodes` | Discover nodes by capability (e.g. "gmail", "slack", "schedule trigger"). Returns IDs plus discriminators (resource/operation/mode). |
 | `get_node_types` | Fetch exact TypeScript parameter definitions for node IDs. **Required before configuring any node.** Don't guess parameter names. |
 | `create_workflow_from_code` | Save a workflow from SDK code. Always include a 1-2 sentence `description`. Pass `skillsUsed` (below). |
-| `update_workflow` | Apply atomic ops to an existing workflow (max 100, all-or-nothing): node/connection CRUD, credential binding, settings, metadata. Saves a draft; needs `publish_workflow` to go live. Pass `skillsUsed` (below). |
+| `update_workflow` | Apply atomic ops to an existing workflow (max 100, all-or-nothing): node/connection CRUD, credential binding, settings, metadata, tags (`addTags`/`removeTags`, auto-creating unknown names). Saves a draft; needs `publish_workflow` to go live. Pass `skillsUsed` (below). |
 | `validate_node_config` | Schema-only validation of node configs (1-50 per call). Per-parameter errors, no graph noise. Side-channel for iteration/debug; `validate_workflow` still gates publish. For ai_tool subnodes set `isToolNode: true`. |
 | `validate_workflow` | Validate full SDK code before create/update. Necessary but **not sufficient**: doesn't catch all wiring traps (`.to()`, merge index). |
 | `list_credentials` | List accessible credentials (filter by type/project/etc). Returns metadata only, **never secret values**. Discover IDs before binding via `setNodeCredential`. |

--- a/skills/n8n-agents/references/SUBWORKFLOW_AS_TOOL.md
+++ b/skills/n8n-agents/references/SUBWORKFLOW_AS_TOOL.md
@@ -97,7 +97,7 @@ Encapsulation: the sub-workflow can be refactored heavily without changing what 
 
 Goal: an agent that can generate or edit images. Both share most logic (prompt → Gemini → upload → return URL), but they differ in whether they download an existing image first.
 
-**Sub-workflow `Subworkflow: Generate or edit image`:**
+**Sub-workflow `Generate or edit image` (tags `subworkflow`, `tool`):**
 
 ```
 [Execute Workflow Trigger: { imagePrompt, imageName, sessionId }]
@@ -182,9 +182,7 @@ For the broader error story (4xx/5xx mapping, retries, error workflows, deciding
 
 ### Keep tool sub-workflows discoverable
 
-<!-- TEMPORARY: when tags are added, put here that tags should always be put on subworkflows -->
-
-Name them with the standard prefix (`Subworkflow:` or domain-specific). The Tool Workflow node references them by ID (stable), but humans browse the UI by name.
+Tag them with `tool` (plus a domain tag like `customer` where it applies) so `search_workflows({ tags: ['tool'] })` finds them. Attach tags with `update_workflow` `addTags` after creating, since `create_workflow_from_code` can't set tags. Give them a plain descriptive name; the Tool Workflow node references them by ID (stable), and tags carry the category.
 
 ### Wire `onError: 'continueErrorOutput'` on fallible nodes
 

--- a/skills/n8n-extending-mcp/SKILL.md
+++ b/skills/n8n-extending-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: n8n-extending-mcp
-description: 'Use when you want to expose an n8n workflow as a tool the coding agent can call. Two cases. (1) Wrap n8n API capabilities the MCP doesn''t natively expose: folder CRUD, tag CRUD, instance metadata, credential creation. (2) Expose a general-purpose workflow as an agent tool: a workflow that calls a third-party API, runs business logic, or does any task you want the agent to invoke. Triggers on "expose as MCP tool", "build a tool for my agent", "I need to know X" where X isn''t an MCP tool, "create folder", "create tag", or any capability gap.'
+description: 'Use when you want to expose an n8n workflow as a tool the coding agent can call. Two cases. (1) Wrap n8n API capabilities the MCP doesn''t natively expose: folder CRUD, tag rename/delete, instance metadata, credential creation. (2) Expose a general-purpose workflow as an agent tool: a workflow that calls a third-party API, runs business logic, or does any task you want the agent to invoke. Triggers on "expose as MCP tool", "build a tool for my agent", "I need to know X" where X isn''t an MCP tool, "create folder", "rename tag", or any capability gap.'
 ---
 
 <!-- TEMPORARY: update whenever n8n mcp capacities are added. a lot of listed functionalities missing are coming soon -->
@@ -8,7 +8,7 @@ description: 'Use when you want to expose an n8n workflow as a tool the coding a
 
 Any n8n workflow with MCP access enabled becomes a tool the coding agent can call by name. Two common cases:
 
-1. **Wrap n8n capabilities the MCP doesn't expose.** The MCP covers workflow CRUD, validation, execution, data tables, credential listing, execution search, folder/project listing. Still missing: folder CRUD, tag CRUD, instance metadata, credential creation. Build a workflow that hits the n8n API and exposes the result as an agent tool.
+1. **Wrap n8n capabilities the MCP doesn't expose.** The MCP covers workflow CRUD, validation, execution, data tables, credential listing, execution search, folder/project listing, tag listing and attach/detach. Still missing: folder CRUD, tag rename/delete, instance metadata, credential creation. Build a workflow that hits the n8n API and exposes the result as an agent tool.
 2. **Expose a general-purpose workflow as a tool.** A workflow that has nothing to do with n8n itself (calls a third-party API, runs internal business logic, looks something up in a private system) can be MCP-callable. Lets the agent invoke real operations during a coding session.
 
 The MCP calls your workflow as if it were a native tool: input from the `Execute Workflow Trigger`, output from the workflow's last node.
@@ -18,7 +18,7 @@ The MCP calls your workflow as if it were a native tool: input from the `Execute
 Case 1 (wrap n8n capability):
 
 - Folder CRUD (create, rename, move, delete): REST API exists, no MCP tool yet.
-- Tag CRUD (create, list, get, delete): REST API exists, no MCP tool yet.
+- Tag rename/delete: the MCP lists tags (`list_tags`) and attaches/detaches them (`update_workflow` `addTags`/`removeTags`, auto-creating unknown names), but can't rename or delete tag entities. REST API exists for those.
 - Instance metadata (limits, plan info, configured integrations): no MCP tool.
 - Credential creation: REST API exists (`POST /credentials`), no MCP tool yet.
 - Any n8n API operation the MCP doesn't natively expose.
@@ -41,7 +41,7 @@ Don't reach for this for:
 
 ## Protocol
 
-- **Search for existing wrappers first.** `search_workflows({ query: 'Tool:' })` and a capability keyword search. If something matches, use it instead of duplicating.
+- **Search for existing wrappers first.** `search_workflows({ tags: ['tool'] })` and a capability keyword search. If something matches, use it instead of duplicating.
 - **For case 1, build as a stateless, queryable utility.** Takes input, calls n8n's API, returns the result. No side effects. Case 2 may legitimately have side effects (sending, writing); name them in the tool description.
 - **Offer to edit the agent's context file yourself** (CLAUDE.md, AGENTS.md, GEMINI.md, whatever the user's agent reads on session start) to add an entry for the new tool. You have Edit/Write tools, so there's no reason to make the user paste a snippet manually. Ask first since it's their config file, then edit it directly when they say yes.
 

--- a/skills/n8n-subworkflows/SKILL.md
+++ b/skills/n8n-subworkflows/SKILL.md
@@ -3,8 +3,6 @@ name: n8n-subworkflows
 description: Use when building anything multi-step, anything that looks repeatable, anything the user mentions reusing, or any workflow with more than ~10 nodes. Triggers on "reuse", "I do this in another workflow", "extract", "modular", "shared logic", "subworkflow", multi-step builds, or any task that mentions logic the user has built before.
 ---
 
-<!-- TEMPORARY: change workflow prefix searching to tags when tag tools are added to mcp -->
-
 # n8n Sub-workflows
 
 Sub-workflows are reusable functions. The `Execute Workflow Trigger` declares input parameters, the body does work, the last node returns output. Callers invoke it like any other node.
@@ -15,14 +13,14 @@ Without sub-workflows, the same logic gets duplicated across workflows. Bug fixe
 
 ## Non-negotiables
 
-1. **Search before you build.** Before writing logic that handles a generic problem, check if a sub-workflow already exists. Use `search_workflows({ query: 'Subworkflow' })`, `query: '<keyword>'`, etc. The MCP can't filter by tags, so naming is the discovery mechanism.
+1. **Search before you build.** Before writing logic that handles a generic problem, check if a sub-workflow already exists. Filter by tag (`search_workflows({ tags: ['subworkflow'] })`, a domain tag) and/or keyword (`query: '<keyword>'`). Tags are the discovery mechanism (n8n 2.27.0+).
 2. **`Execute Workflow Trigger` uses "Define Below" with typed fields, not passthrough.** Define Below is the only mode that lets agent tools (`fromAi`) and structured callers pass values in. Two exceptions: (a) the sub-workflow specifically needs to receive binary (then it can't be wired as an agent tool directly), or (b) the sub-workflow takes no inputs at all (Define Below requires at least one field). See "Sub-workflow inputs and outputs" below.
 
 ## Strong defaults
 
 - **Anything reusable becomes a sub-workflow.** If a logical chunk could plausibly be needed elsewhere, extract it. Exception: trivial wrappers (one HTTP call, no logic) and tightly-coupled-to-this-caller chunks.
 - **Default to stateless for pure logic** (input → output, no external state). For state-touching logic, build *deliberately* stateful sub-workflows that abstract the operation behind a clean contract (the ORM / repository pattern). What to avoid is *accidental* state: a "validate" sub-workflow that quietly writes to a log table.
-- **Verb-first prefix naming**: `Subworkflow: Parse RFC2822 date`, `Customer: hydrate from Stripe`, `Tool: list available credentials`. The prefix is what `search_workflows` matches on. See `references/NAMING_AND_DISCOVERY.md`.
+- **Tag for discovery**: every sub-workflow gets `subworkflow`, a domain tag (`customer`), and/or `tool`. Tags are what `search_workflows({ tags })` filters on; names stay plain and descriptive (`Parse RFC2822 date`). See `references/NAMING_AND_DISCOVERY.md`.
 - **Description carries keywords.** Input/output shape + representative terms, so varied queries surface it.
 - **Split when input contracts genuinely differ** (binary vs JSON, sync vs async, divergent auth schemes). Don't fit divergent contracts under one trigger via passthrough + internal branching. See `references/SUBWORKFLOW_PATTERNS.md` "Splitting by input shape".
 
@@ -54,9 +52,9 @@ Takes input, returns output. No I/O outside the inputs/outputs. Default for pure
 
 Examples:
 
-- `Subworkflow: Parse RFC2822 date`. Input: date string. Output: ISO date or error.
-- `Subworkflow: Compute MRR from subscription`. Input: subscription object. Output: MRR number.
-- `Subworkflow: Format invoice as HTML`. Input: invoice data. Output: HTML string.
+- `Parse RFC2822 date` (tag `subworkflow`). Input: date string. Output: ISO date or error.
+- `Compute MRR from subscription` (tag `subworkflow`). Input: subscription object. Output: MRR number.
+- `Format invoice as HTML` (tag `subworkflow`). Input: invoice data. Output: HTML string.
 
 When you need the logic again, call it without worrying about side effects firing.
 
@@ -66,10 +64,10 @@ Reads or writes external state behind a clean input/output contract. Comparable 
 
 Examples:
 
-- `Customer: get by id`. Input: id. Output: customer object or `{ ok: false, error: 'not_found' }`. Reads the DB.
-- `Customer: write billing record`. Input: record. Output: `{ ok: true, id }`. Writes the DB.
-- `Audit: append event`. Input: event. Output: `{ ok: true, eventId }`. Writes to a logging store.
-- `Notify: send to on-call`. Input: channel, message. Output: `{ ok: true, messageId }`. Calls Slack/SMTP.
+- `Get customer by id` (tag `customer`). Input: id. Output: customer object or `{ ok: false, error: 'not_found' }`. Reads the DB.
+- `Write customer billing record` (tags `customer`, `billing`). Input: record. Output: `{ ok: true, id }`. Writes the DB.
+- `Append audit event` (tag `audit`). Input: event. Output: `{ ok: true, eventId }`. Writes to a logging store.
+- `Send to on-call` (tag `notification`). Input: channel, message. Output: `{ ok: true, messageId }`. Calls Slack/SMTP.
 
 The point of building these as sub-workflows:
 
@@ -128,15 +126,15 @@ When a webhook workflow is API-shaped, treat it like one. Sub-workflows become m
 
 ```
 Webhook
-  → [Subworkflow: Verify JWT]    # decode + validate; 401 on failure
-  → [Subworkflow: Rate limit]    # check + bump counter; 429 on failure
+  → [Verify JWT]    # decode + validate; 401 on failure
+  → [Rate limit]    # check + bump counter; 429 on failure
   → IF (all middleware ok)
     → Main handler logic
     → Respond 200
   → ELSE → Respond with the 4xx the middleware returned
 ```
 
-Canonical example: custom JWT auth rolled inside n8n. `Subworkflow: Verify JWT` takes the raw `Authorization` header, decodes, validates signature and expiry, returns `{ ok: true, user_id }` or `{ ok: false, status: 401, message }`. The caller IFs on `ok`, responds early on failure, continues on success.
+Canonical example: custom JWT auth rolled inside n8n. `Verify JWT` (tag `subworkflow`) takes the raw `Authorization` header, decodes, validates signature and expiry, returns `{ ok: true, user_id }` or `{ ok: false, status: 401, message }`. The caller IFs on `ok`, responds early on failure, continues on success.
 
 Why a sub-workflow and not inline: every webhook that needs auth calls the same one. Swap the library, rotate the signing key, or add refresh-token logic in a single place. The reuse target is exact, the contract is small, and the failure response shape is consistent across every API endpoint.
 
@@ -148,11 +146,11 @@ You're about to build something you've built before. Stop. Search.
 
 ```
 search_workflows({ query: 'date' })
-search_workflows({ query: 'Customer' })
-search_workflows({ query: 'Subworkflow:' })
+search_workflows({ tags: ['customer'] })
+search_workflows({ tags: ['subworkflow'] })
 ```
 
-If something matches, use it. If not, build it as a sub-workflow so the *next* search finds it. The prefix convention (`Subworkflow:`, `Customer:`, etc.) is what makes that work.
+If something matches, use it. If not, build it as a sub-workflow and tag it so the *next* search finds it. The tag convention (`subworkflow`, domain tags, `tool`) is what makes that work.
 
 ## Linear, long workflows are fine when most of the work is in sub-workflows
 
@@ -198,11 +196,11 @@ If your workflow has 15+ nodes and isn't mostly Execute Workflow calls and branc
 When the user describes something multi-step or generic-sounding:
 
 ```
-1. search_workflows with relevant queries (e.g. 'Subworkflow', the domain prefix, the operation keyword)
+1. search_workflows with relevant tags and/or query (e.g. `tags: ['subworkflow']`, a domain tag, the operation keyword)
 2. If candidates appear, fetch get_workflow_details on the top 1-3
 3. Confirm fit by reading the inputs/outputs and (briefly) the body
 4. If a fit exists → use it. Tell the user "I found `<name>`. Using that."
-5. If no fit exists → build new with the prefix convention so the next search finds it
+5. If no fit exists → build new and tag it (`subworkflow`, domain, `tool`) so the next search finds it
 ```
 
 The "tell the user" step matters. They benefit from knowing what's already in their library.
@@ -298,18 +296,18 @@ For the polling-after-fire-and-forget pattern, see `references/SUBWORKFLOW_PATTE
 | File | Read when |
 |---|---|
 | `references/SUBWORKFLOW_PATTERNS.md` | `mode: 'all'` vs `'each'` default, splitting by input shape (binary/passthrough vs Define Below), fire-and-forget parallelization with Data Table polling |
-| `references/NAMING_AND_DISCOVERY.md` | Naming a new sub-workflow, searching for existing ones, the prefix convention |
+| `references/NAMING_AND_DISCOVERY.md` | Naming and tagging a new sub-workflow, searching for existing ones, the tag convention |
 
 ## Anti-patterns
 
 | Anti-pattern | What goes wrong | Fix |
 |---|---|---|
-| Duplicating the same date-parsing nodes in three workflows | Bug fixes happen in two places, miss the third | Extract to `Subworkflow: Parse <format> date` once |
+| Duplicating the same date-parsing nodes in three workflows | Bug fixes happen in two places, miss the third | Extract to a single `Parse <format> date` sub-workflow (tag `subworkflow`) once |
 | Building a new sub-workflow without searching | Library grows duplicates, and future searches find both | Always `search_workflows` first |
 | Sub-workflow named/described as pure that quietly writes to a log table | Callers can't reason about retry or idempotency, side effect ambushes them | Either make the side effect part of the contract (rename, document, return its result) or move it out |
 | Sub-workflow with no `description` | Won't be found in future searches, nobody knows what it does | Set `description` with input/output shape and purpose |
-| Sub-workflow named `Helper 3` | Name doesn't tell anyone what it does, and doesn't match any prefix-based search | Verb-first prefix name (`Subworkflow: ...`, `Customer: ...`), see `n8n-workflow-lifecycle` `NAMING_CONVENTIONS.md` |
-| Sub-workflow with no `Subworkflow:` / domain prefix | Won't show up under `query: 'Subworkflow'` or domain searches, future you can't find it | Always use a prefix at create time |
+| Sub-workflow named `Helper 3` | Name doesn't tell anyone what it does | Verb-first descriptive name (`Parse RFC2822 date`), see `n8n-workflow-lifecycle` `NAMING_CONVENTIONS.md` |
+| Untagged sub-workflow | Won't show up under any `tags` filter, future you can't find it | Tag it (`subworkflow`, domain, `tool`) right after create via `update_workflow` `addTags` |
 | `Execute Workflow Trigger` set to `passthrough` when not handling binary and not deliberately zero-input | No typed schema means agent tools can't fill parameters via `fromAi`, structured callers can't pass values cleanly | Use "Define Below" with declared `workflowInputs.values` (name + type per field). The exceptions are binary-receiving sub-workflows and sub-workflows that genuinely take no inputs (see "Exception 2") |
 | Passthrough trigger for a zero-input sub-workflow without a Set-to-clear node and explanatory sticky | Body silently reads stray fields from whatever the caller forwarded; future readers think passthrough is for binary | Add a `Set` ("Keep Only Set", no fields) at the top of the body and a sticky on the trigger noting no inputs are expected |
 | Sub-workflow called as an agent tool that expects binary input | Agent tools can't pass binary directly | See `n8n-binary-and-data` `AGENT_TOOL_BINARY.md` for the right pattern |

--- a/skills/n8n-subworkflows/references/NAMING_AND_DISCOVERY.md
+++ b/skills/n8n-subworkflows/references/NAMING_AND_DISCOVERY.md
@@ -1,57 +1,42 @@
-<!-- TEMPORARY: change workflow prefix searching to tags when tag tools are added to mcp -->
-
 # Naming and discovery
 
-A sub-workflow nobody can find gets duplicated. The MCP's only searchable surface is `search_workflows({ query })`, which matches against name and description. **That's the discovery mechanism.** Put discovery hooks in the name and description.
+A sub-workflow nobody can find gets duplicated. Discovery runs on two `search_workflows` surfaces: `tags` (exact-match category filter, AND semantics) and `query` (substring over name and description). **Tags are the primary category mechanism**; the query is keyword search within or across categories.
 
-## Tags don't help here
+## Tags are the discovery mechanism
 
-n8n has tags, but the MCP can't read, write, or filter by them. UI-only concept. Don't rely on tags for AI-side discovery.
+Requires n8n 2.27.0+. Tag every sub-workflow so future searches find it by category:
 
-## The naming convention IS the discovery mechanism
+| Tag | Use for |
+|---|---|
+| `subworkflow` | Stateless generic reusable building block |
+| `<domain>` (`customer`, `billing`, `notification`) | Domain-specific sub-workflow |
+| `tool` | MCP-callable tool (see `n8n-extending-mcp`) |
 
-Verb-first prefix names from `n8n-workflow-lifecycle`'s `NAMING_CONVENTIONS.md`:
+Tags compose, so a customer-domain tool carries `customer` + `tool`. How they drive `search_workflows`:
 
-```
-Subworkflow: <verb> <object>            # Stateless generic sub-workflow
-<Domain>: <verb> <object>        # Domain-specific
-Tool: <description>              # MCP-callable tool
-```
+- `{ tags: ['subworkflow'] }` returns every reusable sub-workflow.
+- `{ tags: ['customer'] }` returns every customer-domain workflow.
+- `{ tags: ['tool'] }` returns every MCP-callable tool.
+- `{ tags: ['customer', 'tool'] }` returns customer-domain tools only (AND: must have both).
+- `{ query: 'date' }` returns anything with "date" in name or description, regardless of tag.
+- `{ tags: ['subworkflow'], query: 'parse' }` narrows to parsing sub-workflows.
 
-Examples:
-
-- `Subworkflow: Parse RFC2822 date`
-- `Subworkflow: Compute MRR from subscription`
-- `Subworkflow: Format invoice as HTML`
-- `Customer: hydrate from Stripe`
-- `Customer: write to billing table`
-- `Billing: compute MRR`
-- `Notification: send + log`
-- `Tool: list available credentials`
-
-Why this works for `search_workflows({ query })`:
-
-- `query: 'Subworkflow:'` returns every reusable sub-workflow.
-- `query: 'Customer:'` returns every customer-domain sub-workflow.
-- `query: 'Tool:'` returns every MCP-callable tool.
-- `query: 'date'` returns anything with "date" in name or description, regardless of prefix.
-
-Use the prefix on every sub-workflow.
+`list_tags` shows the instance's existing tag vocabulary. Check it before inventing a tag so you reuse exact names: AND-filtering and `addTags` are case- and spelling-exact, so `customer` and `Customers` are two different tags.
 
 ## Search-before-build, in detail
 
 Before writing logic for a generic problem:
 
 ```
-search_workflows({ query: 'Subworkflow' })                  # all sub-workflows
-search_workflows({ query: 'date' })                  # anything date-related
-search_workflows({ query: 'Customer' })              # customer-domain
-search_workflows({ query: 'Subworkflow: Parse' })           # specific shape
+search_workflows({ tags: ['subworkflow'] })                 # all sub-workflows
+search_workflows({ query: 'date' })                         # anything date-related
+search_workflows({ tags: ['customer'] })                    # customer-domain
+search_workflows({ tags: ['subworkflow'], query: 'parse' }) # specific shape
 ```
 
-When to search: any time you're about to build something that fits a domain or operation keyword. About to parse a date? Query `date`. Format an invoice? Query `invoice`. Send a Slack notification? Query `Slack` and `Notification`.
+When to search: any time you're about to build something that fits a domain or operation keyword. About to parse a date? Query `date`. Format an invoice? Query `invoice`. Send a Slack notification? Query `Slack` or filter `tags: ['notification']`.
 
-Two queries is fine, and the cost is low. Better to over-search than duplicate.
+Two searches is fine, and the cost is low. Better to over-search than duplicate.
 
 If a candidate matches, fetch `get_workflow_details` and read the `description`. If inputs/outputs fit, use it. If close-but-not-quite, decide whether to extend the existing one or build a variant.
 
@@ -74,19 +59,24 @@ This tells the reader: what it does, the output shape, and the typical use case.
 
 Description also feeds `search_workflows` matching. Include representative keywords (e.g., "RFC2822", "date", "ISO", "webhook") so varied queries surface it.
 
-## Naming at create time
+## Naming and tagging at create time
 
-Set the name correctly when calling `create_workflow_from_code`:
+`create_workflow_from_code` sets name and description but **can't set tags**, so tag in a follow-up `update_workflow`:
 
 ```ts
 create_workflow_from_code({
-    name: 'Subworkflow: Parse RFC2822 date',
+    name: 'Parse RFC2822 date',
     description: 'Parses an RFC2822-formatted date string into ISO format. ...',
     code: '...',
 })
+// then, on the returned workflow id:
+update_workflow({
+    workflowId,
+    operations: [{ type: 'addTags', names: ['subworkflow'] }],
+})
 ```
 
-Easier than retrofitting. Don't let new sub-workflows ship without the prefix convention.
+`addTags` auto-creates `subworkflow` if the instance doesn't have it yet (needs the `tag:create` permission; without it, addTags errors on unknown names, so create the tag in the UI first). Don't let new sub-workflows ship untagged: an untagged one won't surface under any `tags` filter.
 
 ## Cross-project sub-workflows
 
@@ -97,7 +87,7 @@ Only share cross-project when both apply:
 - **Stateless**: no project-scoped credentials, data tables, or other state that wouldn't make sense outside the owning project.
 - **Generic problem**: date parsing, ID generation, signature validation, formatting. Things that are clearly not coupled to one project's domain.
 
-A stateful sub-workflow (`Customer: get by id`) shared across projects pulls one project's data into another's workflows, which is almost never what's intended. Keep those in-project, and let each project own its repository layer.
+A stateful sub-workflow (`Get customer by id`, tag `customer`) shared across projects pulls one project's data into another's workflows, which is almost never what's intended. Keep those in-project, and let each project own its repository layer.
 
 For cross-project sub-workflows that meet the bar:
 
@@ -108,31 +98,32 @@ For cross-project sub-workflows that meet the bar:
 
 Roughly:
 
-- 5 to 20 `Subworkflow:` sub-workflows for common shapes (date parsing, ID generation, formatting, etc.).
-- A handful of domain sub-workflows per main domain (`Customer:`, `Billing:`, `Notification:`).
+- 5 to 20 `subworkflow`-tagged sub-workflows for common shapes (date parsing, ID generation, formatting, etc.).
+- A handful per main domain tag (`customer`, `billing`, `notification`).
 - Fewer per-domain "operations" sub-workflows (write to billing table, send email + log).
 
 Counter-examples:
 
 - 100 sub-workflows: likely lots of near-duplicates to merge.
 - 0 sub-workflows: no extraction, logic is being duplicated.
-- 50 sub-workflows named `Helper`, `Util1`, `Helper2`: discoverability broken. Rename.
+- 50 sub-workflows named `Helper`, `Util1`, `Helper2` and untagged: discoverability broken. Rename and tag.
 
 ## When the user asks "what sub-workflows do we have?"
 
-Run a name-prefix search:
+Filter by tag:
 
 ```
-search_workflows({ query: 'Subworkflow:' })
+search_workflows({ tags: ['subworkflow'] })
 ```
 
-Return a list with name + 1-line summary from each `description`. Good moment to spot duplicates and propose consolidating.
+Return a list with name + 1-line summary from each `description`. Good moment to spot duplicates and propose consolidating. `list_tags` (which returns `usageCount` per tag) also gives a fast read on how the library is categorized.
 
 ## Renaming and reorganizing
 
 For duplicates or poorly-named sub-workflows:
 
 - Renaming preserves the workflow ID, so existing `Execute Workflow` callers still work. Search picks up the new name immediately.
+- Re-categorize with `update_workflow` `addTags`/`removeTags` (e.g. drop `subworkflow`, add `tool`). Tag changes don't touch the workflow ID either.
 - n8n has no alias mechanism. Just rename, update any sticky-note references, move on.
 
 For mass renames, audit callers via `search_workflows` and inspect each result's `Execute Workflow` references for the old workflow ID.

--- a/skills/n8n-subworkflows/references/SUBWORKFLOW_PATTERNS.md
+++ b/skills/n8n-subworkflows/references/SUBWORKFLOW_PATTERNS.md
@@ -50,19 +50,19 @@ Each outer sub-workflow does its input-specific prep (validation, fetching, norm
 A "process this paper" capability that can come from either an external ID or a user-uploaded PDF:
 
 ```
-Subworkflow: Process Paper from External ID
+Process Paper from External ID            (tag subworkflow)
   Trigger: Define Below { arxivId: string, source: string }
     → [Validate ID, dedup, fetch metadata, download PDF, extract text]
-    → [Execute Workflow: Subworkflow: Summarize and Store Paper]
+    → [Execute Workflow: Summarize and Store Paper]
         with { arxivId, title, authors, body, source, ... }
 
-Subworkflow: Process Paper from Uploaded PDF
+Process Paper from Uploaded PDF           (tag subworkflow)
   Trigger: Passthrough  (required: binary flows through)
     → [Hash binary for synthetic ID, dedup, extract text]
-    → [Execute Workflow: Subworkflow: Summarize and Store Paper]
+    → [Execute Workflow: Summarize and Store Paper]
         with { arxivId: '<synthetic>', title, body, source: 'upload', ... }
 
-Subworkflow: Summarize and Store Paper          (the shared core)
+Summarize and Store Paper                 (the shared core, tag subworkflow)
   Trigger: Define Below { arxivId, title, body, source, ... }
     → [LLM with structured output, Data Table Insert, return result]
 ```

--- a/skills/n8n-workflow-lifecycle/SKILL.md
+++ b/skills/n8n-workflow-lifecycle/SKILL.md
@@ -71,8 +71,8 @@ For full conventions (verb-noun patterns, capitalization, prefixes), read `refer
 
 - **Workflows:** verb-first, scoped. `Send weekly customer report` not `Customer report sender`.
 - **Nodes:** describe what they *do* in this workflow, not the node type. `Fetch active customers` not `Postgres1`.
-- **Sub-workflows:** prefix with the domain or `Subworkflow:` for stateless reusable ones. `Subworkflow: Parse RFC2822 date`. The prefix is what `search_workflows({ query })` matches on. See `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
-- **Tags:** UI-only. The MCP can't read or write tags, so they're for humans browsing the UI. Don't rely on them for AI discovery.
+- **Sub-workflows:** plain descriptive name (`Parse RFC2822 date`); carry the category in tags (`subworkflow`, a domain tag, `tool`), not a name prefix. `search_workflows({ tags })` filters on them. See `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
+- **Tags:** the AI-side discovery mechanism (n8n 2.27.0+). The MCP lists (`list_tags`), filters (`search_workflows({ tags })`), and attaches them (`update_workflow` `addTags`/`removeTags`, auto-creating unknown names). Lowercase, 2-4 per workflow. See `references/NAMING_CONVENTIONS.md`.
 
 ## Readability: descriptions, sticky notes, conventions
 

--- a/skills/n8n-workflow-lifecycle/references/NAMING_CONVENTIONS.md
+++ b/skills/n8n-workflow-lifecycle/references/NAMING_CONVENTIONS.md
@@ -25,21 +25,23 @@ Sentence case, not Title Case. Easier to scan, and matches normal prose. Acronym
 
 ### Punctuation
 
-- Colon for category prefix: `Subworkflow: Parse RFC2822 date`, `Daily: clean up stale Slack DMs`.
+- Colon for category prefix on top-level workflows: `Daily: clean up stale Slack DMs`, `Webhook: report-request`. Sub-workflows categorize by tag, not name prefix (see Sub-workflows and Tags below).
 - No emojis in workflow names. They break in URLs, search, and CLI tools.
 - No trailing version numbers (`v2`, `final`). For versioning, archive the old one or use git on the SDK code.
 
 ## Sub-workflows
 
-Same verb-first rule, but prefix with a domain or `Subworkflow:` for stateless sub-workflows reusable anywhere.
+Same verb-first rule. The name says what the sub-workflow does; a **tag** says what kind it is. Category lives in tags, not a name prefix.
 
-| Pattern | Example |
+| Name | Tags |
 |---|---|
-| `Subworkflow: <verb> <object>` | `Subworkflow: Fetch JSON with retry`, `Subworkflow: Parse RFC2822 date` |
-| `<Domain>: <verb> <object>` | `Customer: hydrate from Stripe`, `Billing: compute MRR` |
-| `Tool: <description>` | `Tool: list available credentials` (for MCP-extending workflows, see `n8n-extending-mcp`) |
+| `Fetch JSON with retry` | `subworkflow` |
+| `Parse RFC2822 date` | `subworkflow` |
+| `Hydrate customer from Stripe` | `customer`, `subworkflow` |
+| `Compute MRR` | `billing` |
+| `List available credentials` | `tool` (MCP-extending workflows, see `n8n-extending-mcp`) |
 
-The prefix isn't a folder, it's a name pattern. It exists as a workaround: the MCP currently doesn't expose tags, and `search_workflows` matches only against name and description, so prefixes act as the searchable category mechanism. If/when the MCP adds tag support, this convention should shift from prefix-based to tag-based; the prefix is a temporary stand-in for what tags will eventually do better.
+Tags compose: a customer-domain tool carries `customer` + `tool`. `search_workflows({ tags })` filters on them with AND semantics (a workflow must have every listed tag). This replaces the old name-prefix convention, which only existed because the MCP couldn't filter by tags. Full discovery protocol: `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
 
 ## Nodes
 
@@ -69,22 +71,18 @@ For `Merge`, name after what's being merged (`Merge customer + Stripe data`).
 
 ## Tags
 
-Tags are UI-only. The n8n MCP cannot create, attach, read, or filter by tags, and the SDK doesn't expose a tags field. Useful for **humans** browsing the UI, but **not** an AI discovery mechanism.
+Tags are the AI-side discovery and categorization mechanism (n8n 2.27.0+). The MCP can read them (`list_tags`), filter by them (`search_workflows({ tags })`, AND semantics), and attach/detach them (`update_workflow` `addTags`/`removeTags`). `addTags` auto-creates an unknown tag, so you never pre-register one. It cannot rename or delete tag entities, and `create_workflow_from_code` can't set tags at create time, so tag right after creating.
 
-If tagging in the UI:
+Tag names are now exact-match machine identifiers, not just human labels:
 
-- All lowercase, with spaces (not hyphens): `customer data`, `daily report`, `util`, `prod`.
-- Optionally lead with an emoji as a quick visual category marker: `🧰 util`, `📊 daily report`, `💵 financial`. Use it consistently within a project or skip it entirely. Mixing tagged-with-emoji and tagged-without-emoji within the same project defeats the purpose.
-- Aim for up to 2-4 per workflow, since more can be noise.
+- All lowercase, spaces not hyphens: `customer`, `daily report`, `util`, `prod`. A case or spelling mismatch is a different tag.
+- No emojis. `addTags` and the `tags` filter match names exactly, so an emoji makes every match fragile.
+- **`list_tags` before tagging** to reuse the instance's existing names instead of spawning near-duplicates (`customer` vs `customers`).
+- Aim for 2-4 per workflow. More is noise.
 
-### Discovery is name-based, not tag-based
+Standard category tags: `subworkflow` (reusable building block), a domain tag (`customer`, `billing`, `notification`), and `tool` (MCP-callable, see `n8n-extending-mcp`). For the full discovery protocol, see `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
 
-`search_workflows({ query })` matches name and description only. To make a sub-workflow findable, the name must contain the discovery hook:
-
-- Verb-first prefix: `Subworkflow: Parse RFC2822 date`, `Customer: hydrate from Stripe`, `Tool: list available credentials`.
-- Description carries representative keywords.
-
-For the full naming-and-discovery protocol, see `n8n-subworkflows` `references/NAMING_AND_DISCOVERY.md`.
+Instance and user conventions overrule all of the above. If `list_tags` shows an existing vocabulary, or the user prefers different names, casing, or categories, match theirs. Consistency within an instance beats this skill's defaults.
 
 ## Workflow `description`
 

--- a/skills/n8n-workflow-lifecycle/references/REVIEW_CHECKLIST.md
+++ b/skills/n8n-workflow-lifecycle/references/REVIEW_CHECKLIST.md
@@ -235,7 +235,7 @@ The system prompt is the load-bearing config of an agent. Severity ranges by how
 ### Naming
 
 - [ ] **Workflow name doesn't follow verb-first pattern** (`Send weekly customer report` vs. `Customer report sender`). → [NAMING_CONVENTIONS.md](NAMING_CONVENTIONS.md)
-- [ ] **Sub-workflow without a discoverable prefix** (`Subworkflow:`, `<Domain>:`, `Tool:`). The MCP can't filter by tags; naming is the discovery mechanism. → [NAMING_AND_DISCOVERY.md](../../n8n-subworkflows/references/NAMING_AND_DISCOVERY.md)
+- [ ] **Untagged sub-workflow** (missing `subworkflow`, a domain tag, or `tool`). Tags are the discovery mechanism; an untagged sub-workflow won't surface under any `tags` filter. → [NAMING_AND_DISCOVERY.md](../../n8n-subworkflows/references/NAMING_AND_DISCOVERY.md)
 
 ### Readability
 

--- a/skills/n8n-workflow-lifecycle/references/VALIDATION_CHECKLIST.md
+++ b/skills/n8n-workflow-lifecycle/references/VALIDATION_CHECKLIST.md
@@ -88,7 +88,7 @@ Fix and re-test if anything's off.
 
 Quick pass:
 
-- Workflow name follows the verb-first pattern (`NAMING_CONVENTIONS.md`). Sub-workflows use a prefix (`Subworkflow:`, `<Domain>:`, `Tool:`) since that's how `search_workflows` finds them.
+- Workflow name follows the verb-first pattern (`NAMING_CONVENTIONS.md`). Sub-workflows are tagged (`subworkflow`, a domain tag, `tool`) since that's how `search_workflows({ tags })` finds them.
 - `description` is set and captures both *what* and *why*, with searchable keywords.
 - Nodes are renamed from defaults.
 

--- a/skills/using-n8n-skills/SKILL.md
+++ b/skills/using-n8n-skills/SKILL.md
@@ -26,7 +26,7 @@ Unless a user preference overrides it, err on the side of loading too many skill
 ## Strong defaults (each skill owns its exceptions)
 
 - **The Code node is a last resort.** Expression first, then arrow function inside Edit Fields, then Code. Code earns its place for multi-source aggregation, libraries, and stateful work. See `n8n-code-nodes`.
-- **Anything reusable becomes a stateless sub-workflow.** Search existing ones via `search_workflows({ query: 'Subworkflow' })` before building. See `n8n-subworkflows`.
+- **Anything reusable becomes a stateless sub-workflow.** Search existing ones via `search_workflows({ tags: ['subworkflow'] })` before building. See `n8n-subworkflows`.
 
 ## Red flags: thoughts that mean STOP and invoke
 
@@ -59,7 +59,7 @@ Invoke via the Skill tool. Trigger column = when to invoke.
 | Skill | Trigger |
 |---|---|
 | `n8n-workflow-lifecycle` | Starting, designing, organizing, or finishing a workflow. Covers sticky-note conventions, descriptions that capture the *why*, naming, validation checklist, folder limitations, MCP-access-per-workflow gotcha |
-| `n8n-subworkflows` | Anything reusable, multi-step builds, or the user mentions reuse. Search before building, stateless patterns, naming-prefix convention for discovery |
+| `n8n-subworkflows` | Anything reusable, multi-step builds, or the user mentions reuse. Search before building, stateless patterns, tag-based discovery convention |
 | `n8n-extending-mcp` | You need capabilities the MCP doesn't natively provide. Wrap n8n APIs as workflow tools, with user permission |
 | `n8n-expressions` | Writing `{{}}`, `$json`, `$node`, expression errors. Luxon for dates, indented multi-line, prefer expressions over extra nodes |
 | `n8n-node-configuration` | Configuring any node. Operation-aware, property dependencies, never assume parameters |
@@ -82,10 +82,11 @@ Tool names are shown without the MCP prefix. The qualified name is `mcp__<server
 
 | Tool | What it does |
 |---|---|
-| `search_workflows` | Search workflows across the instance by `query` (matches name and description, but tags are not filterable via MCP). The **only** cross-workflow tool. Use it to discover what already exists. |
+| `search_workflows` | Search workflows across the instance by `query` (substring on name/description) and/or `tags` (exact tag names, AND semantics: must have all). The **only** cross-workflow tool. Use it to discover what already exists. |
 | `get_workflow_details` | Fetch a workflow's full JSON by ID. Use after every create/update to verify connections. |
 | `search_folders` | List folders. **You cannot create or move folders.** You can only place workflows into folders that already exist. |
 | `search_projects` | List projects. |
+| `list_tags` | List all workflow tags (with `usageCount` per tag). Check the instance's tag vocabulary before tagging or filtering, so you reuse exact names. Tags are attached/detached via `update_workflow` `addTags`/`removeTags`; there's no tag rename/delete tool. |
 | `archive_workflow` / `publish_workflow` / `unpublish_workflow` | Soft-delete / activate / deactivate. Validate before publish. |
 | `search_executions` | Search executions across the instance (filter by status, workflow, time range). Use for "list recent runs" / "failures in the last hour". Single executions: `get_execution`. |
 
@@ -98,7 +99,7 @@ Tool names are shown without the MCP prefix. The qualified name is `mcp__<server
 | `search_nodes` | Discover nodes by capability (e.g. "gmail", "slack", "schedule trigger"). Returns IDs plus discriminators (resource/operation/mode). |
 | `get_node_types` | Fetch exact TypeScript parameter definitions for node IDs. **Required before configuring any node.** Don't guess parameter names. |
 | `create_workflow_from_code` | Save a workflow from SDK code. Always include a 1-2 sentence `description`. Pass `skillsUsed` (below). |
-| `update_workflow` | Apply atomic ops to an existing workflow (max 100, all-or-nothing): node/connection CRUD, credential binding, settings, metadata. Saves a draft; needs `publish_workflow` to go live. Pass `skillsUsed` (below). |
+| `update_workflow` | Apply atomic ops to an existing workflow (max 100, all-or-nothing): node/connection CRUD, credential binding, settings, metadata, tags (`addTags`/`removeTags`, auto-creating unknown names). Saves a draft; needs `publish_workflow` to go live. Pass `skillsUsed` (below). |
 | `validate_node_config` | Schema-only validation of node configs (1-50 per call). Per-parameter errors, no graph noise. Side-channel for iteration/debug; `validate_workflow` still gates publish. For ai_tool subnodes set `isToolNode: true`. |
 | `validate_workflow` | Validate full SDK code before create/update. Necessary but **not sufficient**: doesn't catch all wiring traps (`.to()`, merge index). |
 | `list_credentials` | List accessible credentials (filter by type/project/etc). Returns metadata only, **never secret values**. Discover IDs before binding via `setNodeCredential`. |


### PR DESCRIPTION
n8n 2.27.0 added tag support to the built-in MCP server, so the old name-prefix discovery convention (`Subworkflow:`, `Customer:`, `Tool:`) is now a workaround for a gap that's closed. This switches sub-workflow/tool discovery to real tags and fixes every stale "tags are UI-only" claim. Closes #27.

Every factual claim below was verified against the current n8n `master` source (module `packages/cli/src/modules/mcp/`), not the docs, which lag.

## What the MCP now does with tags

- **`list_tags`**: reads all tags with a `usageCount` per tag.
- **`search_workflows({ tags })`**: filters by tag names with AND semantics (a workflow must have every listed tag).
- **`update_workflow` `addTags`/`removeTags`**: attach/detach by name. `addTags` auto-creates an unknown tag (needs the `tag:create` scope; without it, it errors naming the missing tags), `removeTags` ignores unknown names.
- **Still missing**: no `create_tag`/`rename_tag`/`delete_tag` tool, and `create_workflow_from_code` can't set tags at create time, so you create then tag via a follow-up `update_workflow`. All three tag features landed together in 2.27.0 (n8n-io/n8n#31446).

## The paradigm shift

- **Category moves from name to tag.** Names become plain and descriptive (`Parse RFC2822 date`); the category lives in tags (`subworkflow`, a domain tag like `customer`, `tool`). Tags compose, so a customer-domain tool carries `customer` + `tool`, and `search_workflows({ tags: ['customer', 'tool'] })` narrows via AND.
- **Discovery is tag-first.** `search_workflows({ tags })` for category, `query` for keyword, combined for both. `list_tags` before tagging so you reuse the instance's exact names (matching is case- and spelling-exact now).
- **Tag names are machine identifiers**, so the naming rules got stricter: lowercase, no emojis, 2-4 per workflow. Instance/user conventions overrule the defaults.

## Files touched

- **`n8n-subworkflows`**: `NAMING_AND_DISCOVERY.md` rewritten around tags (search examples, create-then-`addTags` flow, re-tagging). `SKILL.md` non-negotiables, defaults, protocol, anti-patterns, and all example names retagged. `SUBWORKFLOW_PATTERNS.md` example names.
- **`n8n-workflow-lifecycle`**: `NAMING_CONVENTIONS.md` Sub-workflows + Tags sections rewritten. `SKILL.md`, `REVIEW_CHECKLIST.md`, `VALIDATION_CHECKLIST.md` naming/tag rules.
- **`n8n-extending-mcp`**: capability gap narrowed to tag rename/delete only (description + body + wrapper search).
- **`using-n8n-skills`**: added `list_tags` to the MCP tool table; fixed `search_workflows` (now tag-filterable) and `update_workflow` (addTags/removeTags); router wording.
- **`n8n-agents/references/SUBWORKFLOW_AS_TOOL.md`**: tag tool sub-workflows with `tool`.
- Removed all three resolved `<!-- TEMPORARY: ...tags... -->` markers.

_writing assistance from claude_

## Housekeeping

- **Rebased onto current `main`** (the branch had started from a pre-#16 main). Resolved one conflict in the `n8n-extending-mcp` description: kept #16's YAML quoting, applied the tag-content change.
- **Regenerated the Codex bundle** (`scripts/sync-codex-bundle.sh`) so `plugins/n8n-skills/` mirrors the edited skills; `git diff --exit-code` passes.
- **Bumped version 0.3.1 → 0.4.0** (shipped skill content changed; adopting a new MCP surface, matching the 0.3.0 minor-bump precedent).
