### PR TITLE
docs: add explore_node_resources guidance

### DIFF
--- a/plugins/n8n-skills/skills/n8n-credentials-and-security/SKILL.md
+++ b/plugins/n8n-skills/skills/n8n-credentials-and-security/SKILL.md
@@ -15,6 +15,7 @@ description: Use when handling any auth, API keys, tokens, OAuth, bearer tokens,
 
 - **Use native credentials when available.** Every native node (Slack, Gmail, Postgres, OpenAI, etc.) has a credential type. Don't reach for generic credential types when a native option exists.
 - **For multi-header or header-plus-query auth shapes**, use the `httpCustomAuth` credential type. See `references/CUSTOM_CREDENTIALS.md`.
+- **Use credentials to resolve live resource lists.** If a node needs sheets, channels, databases, or model IDs from an authenticated account, call `explore_node_resources` after `list_credentials` instead of asking the user for raw IDs.
 
 ## The credential system
 
@@ -28,6 +29,8 @@ In n8n, credentials are first-class objects:
 A node that needs auth has a `credentials` parameter pointing to a credential ID + type. Secret values never appear in workflow JSON. Exporting a workflow leaks the *reference*, not the secret.
 
 For the full model (SDK resolution, rotation, project scoping), see `references/CREDENTIAL_SYSTEM.md`.
+
+The same credential can also power discovery. When a node has a resource-locator or load-options field, use `explore_node_resources` with the credential ID to fetch the real values from that account.
 
 ## Decision tree: how to authenticate this thing
 
@@ -85,8 +88,9 @@ Common case: the user wants a service n8n has no node for. Use HTTP Request with
 |---|---|---|
 | Pasting `sk-...` into HTTP Request's `Authorization` header value field | Token in plain text in the workflow JSON, leaks on export, copy, screenshot | Use a credential: `Bearer Auth` for bearer tokens, `Header Auth` for other custom auth schemes |
 | Storing token in a Set node and referencing via expression | Same problem, value lives in workflow JSON | Same fix: credential, not a Set node |
-| Storing a secret in `$vars.X` and reading it as the auth value | Not encrypted at rest, leaks in exports, no rotation | Use the right credential type (`httpBearerAuth`, `httpHeaderAuth`, `httpCustomAuth`, or the native one). For inbound webhook auth, use the trigger's `authentication` field, not an IF on `$vars.token` |
+| Storing a secret in `$vars.X` and reading it as the auth value | Not encrypted at rest, leaks on exports, no rotation | Use the right credential type (`httpBearerAuth`, `httpHeaderAuth`, `httpCustomAuth`, or the native one). For inbound webhook auth, use the trigger's `authentication` field, not an IF on `$vars.token` |
 | Reaching for `$env.X` to read a secret during custom auth setup | Doesn't work, throws at runtime | Use a credential of the appropriate type |
+| Asking the user for raw sheet/channel/database IDs before checking the credentialed account | Slows setup, encourages copy-paste mistakes, ignores live account metadata | `list_credentials` first, then `explore_node_resources` for live options |
 | Using HTTP Request when a native node exists | Loses auto-refresh on OAuth, loses native error handling, more code | Use the native node |
 | Hardcoding credentials in SDK code (`new HttpRequest({ headers: { Authorization: 'Bearer xxx' } })`) | Same leak surface | Use `newCredential()` in SDK code |
 | Asking the user to create a credential without naming the credential *type* | User picks the wrong type, auth fails confusingly | Always specify: "create a credential of type `<exact type name>`" |

--- a/plugins/n8n-skills/skills/n8n-node-configuration/SKILL.md
+++ b/plugins/n8n-skills/skills/n8n-node-configuration/SKILL.md
@@ -19,6 +19,7 @@ Don't guess, use the `get_node_types` tool.
 
 - **Configure operation-first.** Set `resource` and `operation` first, and conditional parameters become visible. Most "field doesn't exist" errors are really "you haven't set the parent operation yet."
 - **Don't carry parameters across operations.** When changing `operation`, re-derive from the new shape. Stale parameters from the previous operation trip validation.
+- **Use `explore_node_resources` for live option lists.** If a field is a resource locator or load-options dropdown, resolve it from the credentialed account instead of guessing IDs or asking for them up front.
 
 ## The flow for any new node
 
@@ -28,13 +29,27 @@ Don't guess, use the `get_node_types` tool.
 2. Pick the right (resource, operation) for the task.
 3. get_node_types([{ name: '...', resource: '...', operation: '...' }])
    → returns exact parameter shape including conditional fields
-4. Build the node config from that shape.
-5. validate_workflow → fix errors.
-6. get_workflow_details → inspect the saved config; confirm parameters landed.
-7. test_workflow with pinned data → confirm runtime behavior.
+4. If the shape includes a resource locator or load-options field, call `explore_node_resources` with the exact method name and a real credential ID.
+5. Build the node config from that shape.
+6. validate_workflow → fix errors.
+7. get_workflow_details → inspect the saved config; confirm parameters landed.
+8. test_workflow with pinned data → confirm runtime behavior.
 ```
 
 Skipping any step compounds the next. The most common skip is step 3, leading to "Cannot read property X" errors that are really "you didn't pass the discriminators."
+
+### Resource locators and load-options
+
+Some node fields are not free-text IDs. They are populated from the connected account: sheet tabs, Slack channels, model lists, Notion databases.
+
+Pattern:
+
+1. Use `get_node_types` to find the exact annotated method name.
+2. Discover or confirm the credential with `list_credentials`.
+3. Call `explore_node_resources` with that credential, the method name, and any already-selected parent fields in `currentNodeParameters`.
+4. Use the returned real value in the node config.
+
+If you skip this and type IDs from memory, you usually get validator-passing configs that fail at runtime or point at the wrong resource.
 
 ### `validate_node_config` as a side-channel
 
@@ -103,6 +118,7 @@ Per-category gotchas. Read the file for the node type you're configuring:
 |---|---|---|
 | Building node config from memory of how the node looked last year | Parameter shape has drifted, validation fails with cryptic errors | Always `get_node_types` per session per node |
 | Skipping discriminators in `get_node_types` | Get generic shape, miss operation-specific required fields | Always pass `resource` + `operation` (and `mode` where present) |
+| Guessing sheet/channel/database IDs for a resource-locator field | Wrong option value, runtime failure, or wrong target resource | Use `explore_node_resources` with the node's exact method name and credential |
 | Copying a node config from one operation to another and tweaking | Stale parameters trip validation, and conditional fields don't apply | Re-derive from the new operation's shape |
 | Hardcoding tokens / credentials in node text fields | Leaks on export. See `n8n-credentials-and-security` | Always credentials |
 | Not testing the node with `test_workflow` after configuring | Runtime errors only surface on real data | Always test with pinned data before publish |

--- a/plugins/n8n-skills/skills/using-n8n-skills/SKILL.md
+++ b/plugins/n8n-skills/skills/using-n8n-skills/SKILL.md
@@ -103,6 +103,7 @@ Tool names are shown without the MCP prefix. The qualified name is `mcp__<server
 | `validate_node_config` | Schema-only validation of node configs (1-50 per call). Per-parameter errors, no graph noise. Side-channel for iteration/debug; `validate_workflow` still gates publish. For ai_tool subnodes set `isToolNode: true`. |
 | `validate_workflow` | Validate full SDK code before create/update. Necessary but **not sufficient**: doesn't catch all wiring traps (`.to()`, merge index). |
 | `list_credentials` | List accessible credentials (filter by type/project/etc). Returns metadata only, **never secret values**. Discover IDs before binding via `setNodeCredential`. |
+| `explore_node_resources` | Resolve live resource-locator and load-options values (sheet names, channels, models) through a credential. Use after `get_node_types` when a field needs a real ID or option value. |
 
 ### Workflow testing & execution
 
@@ -133,8 +134,9 @@ For any n8n task:
 2. **Invoke the skill via the Skill tool** before the first MCP call. Don't call n8n MCP tools blind.
 3. **Read the SDK reference once per session** before writing workflow code (`get_sdk_reference`). The most efficient way to avoid SDK-shape mistakes.
 4. **Get node types before configuring any node** (`get_node_types`). Guessing parameter names creates invalid workflows, sometimes silently.
-5. **Validate before publish, verify after create/update.** Validation catches schema errors. Verification (pulling the workflow back via `get_workflow_details`) catches connection bugs validation misses.
-6. **Surface drift when you spot it.** If a tool or parameter doesn't match what a skill says, tell the user. Updates may be needed.
+5. **Resolve live dropdown/resource-locator values before filling IDs.** When `get_node_types` shows a load-options or resource-locator field, use `explore_node_resources` with a real credential instead of guessing or asking for raw IDs first.
+6. **Validate before publish, verify after create/update.** Validation catches schema errors. Verification (pulling the workflow back via `get_workflow_details`) catches connection bugs validation misses.
+7. **Surface drift when you spot it.** If a tool or parameter doesn't match what a skill says, tell the user. Updates may be needed.
 
 ## Reporting skills used
 

--- a/skills/n8n-credentials-and-security/SKILL.md
+++ b/skills/n8n-credentials-and-security/SKILL.md
@@ -15,6 +15,7 @@ description: Use when handling any auth, API keys, tokens, OAuth, bearer tokens,
 
 - **Use native credentials when available.** Every native node (Slack, Gmail, Postgres, OpenAI, etc.) has a credential type. Don't reach for generic credential types when a native option exists.
 - **For multi-header or header-plus-query auth shapes**, use the `httpCustomAuth` credential type. See `references/CUSTOM_CREDENTIALS.md`.
+- **Use credentials to resolve live resource lists.** If a node needs sheets, channels, databases, or model IDs from an authenticated account, call `explore_node_resources` after `list_credentials` instead of asking the user for raw IDs.
 
 ## The credential system
 
@@ -28,6 +29,8 @@ In n8n, credentials are first-class objects:
 A node that needs auth has a `credentials` parameter pointing to a credential ID + type. Secret values never appear in workflow JSON. Exporting a workflow leaks the *reference*, not the secret.
 
 For the full model (SDK resolution, rotation, project scoping), see `references/CREDENTIAL_SYSTEM.md`.
+
+The same credential can also power discovery. When a node has a resource-locator or load-options field, use `explore_node_resources` with the credential ID to fetch the real values from that account.
 
 ## Decision tree: how to authenticate this thing
 
@@ -85,8 +88,9 @@ Common case: the user wants a service n8n has no node for. Use HTTP Request with
 |---|---|---|
 | Pasting `sk-...` into HTTP Request's `Authorization` header value field | Token in plain text in the workflow JSON, leaks on export, copy, screenshot | Use a credential: `Bearer Auth` for bearer tokens, `Header Auth` for other custom auth schemes |
 | Storing token in a Set node and referencing via expression | Same problem, value lives in workflow JSON | Same fix: credential, not a Set node |
-| Storing a secret in `$vars.X` and reading it as the auth value | Not encrypted at rest, leaks in exports, no rotation | Use the right credential type (`httpBearerAuth`, `httpHeaderAuth`, `httpCustomAuth`, or the native one). For inbound webhook auth, use the trigger's `authentication` field, not an IF on `$vars.token` |
+| Storing a secret in `$vars.X` and reading it as the auth value | Not encrypted at rest, leaks on exports, no rotation | Use the right credential type (`httpBearerAuth`, `httpHeaderAuth`, `httpCustomAuth`, or the native one). For inbound webhook auth, use the trigger's `authentication` field, not an IF on `$vars.token` |
 | Reaching for `$env.X` to read a secret during custom auth setup | Doesn't work, throws at runtime | Use a credential of the appropriate type |
+| Asking the user for raw sheet/channel/database IDs before checking the credentialed account | Slows setup, encourages copy-paste mistakes, ignores live account metadata | `list_credentials` first, then `explore_node_resources` for live options |
 | Using HTTP Request when a native node exists | Loses auto-refresh on OAuth, loses native error handling, more code | Use the native node |
 | Hardcoding credentials in SDK code (`new HttpRequest({ headers: { Authorization: 'Bearer xxx' } })`) | Same leak surface | Use `newCredential()` in SDK code |
 | Asking the user to create a credential without naming the credential *type* | User picks the wrong type, auth fails confusingly | Always specify: "create a credential of type `<exact type name>`" |

--- a/skills/n8n-credentials-and-security/SKILL.md
+++ b/skills/n8n-credentials-and-security/SKILL.md
@@ -30,7 +30,7 @@ A node that needs auth has a `credentials` parameter pointing to a credential ID
 
 For the full model (SDK resolution, rotation, project scoping), see `references/CREDENTIAL_SYSTEM.md`.
 
-The same credential can also power discovery. When a node has a resource-locator or load-options field, use `explore_node_resources` with the credential ID to fetch the real values from that account.
+The same credential can also power discovery. When a node has a resource-locator or load-options field, use `explore_node_resources` with the credential ID, the exact method name from `get_node_types`, and any already-selected parent fields in `currentNodeParameters` to fetch the real values from that account. See `n8n-node-configuration` for the full pattern.
 
 ## Decision tree: how to authenticate this thing
 

--- a/skills/n8n-node-configuration/SKILL.md
+++ b/skills/n8n-node-configuration/SKILL.md
@@ -47,7 +47,7 @@ Pattern:
 1. Use `get_node_types` to find the exact annotated method name.
 2. Discover or confirm the credential with `list_credentials`.
 3. Call `explore_node_resources` with that credential, the method name, and any already-selected parent fields in `currentNodeParameters`.
-4. Use the returned real value in the node config.
+4. Use the returned value in the node config. For resource-locator fields, preserve the full structured object (`__rl`, `mode`, `value`, and any cached metadata) returned by the tool—do not extract just a raw ID. For load-options fields, use the option value directly.
 
 If you skip this and type IDs from memory, you usually get validator-passing configs that fail at runtime or point at the wrong resource.
 

--- a/skills/n8n-node-configuration/SKILL.md
+++ b/skills/n8n-node-configuration/SKILL.md
@@ -19,6 +19,7 @@ Don't guess, use the `get_node_types` tool.
 
 - **Configure operation-first.** Set `resource` and `operation` first, and conditional parameters become visible. Most "field doesn't exist" errors are really "you haven't set the parent operation yet."
 - **Don't carry parameters across operations.** When changing `operation`, re-derive from the new shape. Stale parameters from the previous operation trip validation.
+- **Use `explore_node_resources` for live option lists.** If a field is a resource locator or load-options dropdown, resolve it from the credentialed account instead of guessing IDs or asking for them up front.
 
 ## The flow for any new node
 
@@ -28,13 +29,27 @@ Don't guess, use the `get_node_types` tool.
 2. Pick the right (resource, operation) for the task.
 3. get_node_types([{ name: '...', resource: '...', operation: '...' }])
    → returns exact parameter shape including conditional fields
-4. Build the node config from that shape.
-5. validate_workflow → fix errors.
-6. get_workflow_details → inspect the saved config; confirm parameters landed.
-7. test_workflow with pinned data → confirm runtime behavior.
+4. If the shape includes a resource locator or load-options field, call `explore_node_resources` with the exact method name and a real credential ID.
+5. Build the node config from that shape.
+6. validate_workflow → fix errors.
+7. get_workflow_details → inspect the saved config; confirm parameters landed.
+8. test_workflow with pinned data → confirm runtime behavior.
 ```
 
 Skipping any step compounds the next. The most common skip is step 3, leading to "Cannot read property X" errors that are really "you didn't pass the discriminators."
+
+### Resource locators and load-options
+
+Some node fields are not free-text IDs. They are populated from the connected account: sheet tabs, Slack channels, model lists, Notion databases.
+
+Pattern:
+
+1. Use `get_node_types` to find the exact annotated method name.
+2. Discover or confirm the credential with `list_credentials`.
+3. Call `explore_node_resources` with that credential, the method name, and any already-selected parent fields in `currentNodeParameters`.
+4. Use the returned real value in the node config.
+
+If you skip this and type IDs from memory, you usually get validator-passing configs that fail at runtime or point at the wrong resource.
 
 ### `validate_node_config` as a side-channel
 
@@ -103,6 +118,7 @@ Per-category gotchas. Read the file for the node type you're configuring:
 |---|---|---|
 | Building node config from memory of how the node looked last year | Parameter shape has drifted, validation fails with cryptic errors | Always `get_node_types` per session per node |
 | Skipping discriminators in `get_node_types` | Get generic shape, miss operation-specific required fields | Always pass `resource` + `operation` (and `mode` where present) |
+| Guessing sheet/channel/database IDs for a resource-locator field | Wrong option value, runtime failure, or wrong target resource | Use `explore_node_resources` with the node's exact method name and credential |
 | Copying a node config from one operation to another and tweaking | Stale parameters trip validation, and conditional fields don't apply | Re-derive from the new operation's shape |
 | Hardcoding tokens / credentials in node text fields | Leaks on export. See `n8n-credentials-and-security` | Always credentials |
 | Not testing the node with `test_workflow` after configuring | Runtime errors only surface on real data | Always test with pinned data before publish |

--- a/skills/using-n8n-skills/SKILL.md
+++ b/skills/using-n8n-skills/SKILL.md
@@ -103,6 +103,7 @@ Tool names are shown without the MCP prefix. The qualified name is `mcp__<server
 | `validate_node_config` | Schema-only validation of node configs (1-50 per call). Per-parameter errors, no graph noise. Side-channel for iteration/debug; `validate_workflow` still gates publish. For ai_tool subnodes set `isToolNode: true`. |
 | `validate_workflow` | Validate full SDK code before create/update. Necessary but **not sufficient**: doesn't catch all wiring traps (`.to()`, merge index). |
 | `list_credentials` | List accessible credentials (filter by type/project/etc). Returns metadata only, **never secret values**. Discover IDs before binding via `setNodeCredential`. |
+| `explore_node_resources` | Resolve live resource-locator and load-options values (sheet names, channels, models) through a credential. Use after `get_node_types` when a field needs a real ID or option value. |
 
 ### Workflow testing & execution
 
@@ -133,8 +134,9 @@ For any n8n task:
 2. **Invoke the skill via the Skill tool** before the first MCP call. Don't call n8n MCP tools blind.
 3. **Read the SDK reference once per session** before writing workflow code (`get_sdk_reference`). The most efficient way to avoid SDK-shape mistakes.
 4. **Get node types before configuring any node** (`get_node_types`). Guessing parameter names creates invalid workflows, sometimes silently.
-5. **Validate before publish, verify after create/update.** Validation catches schema errors. Verification (pulling the workflow back via `get_workflow_details`) catches connection bugs validation misses.
-6. **Surface drift when you spot it.** If a tool or parameter doesn't match what a skill says, tell the user. Updates may be needed.
+5. **Resolve live dropdown/resource-locator values before filling IDs.** When `get_node_types` shows a load-options or resource-locator field, use `explore_node_resources` with a real credential instead of guessing or asking for raw IDs first.
+6. **Validate before publish, verify after create/update.** Validation catches schema errors. Verification (pulling the workflow back via `get_workflow_details`) catches connection bugs validation misses.
+7. **Surface drift when you spot it.** If a tool or parameter doesn't match what a skill says, tell the user. Updates may be needed.
 
 ## Reporting skills used
 


### PR DESCRIPTION
## Summary
- add `explore_node_resources` to the meta-skill MCP tool list
- document when to use it for resource-locator and load-options fields
- update credential guidance so live option discovery uses the bound credential instead of asking for raw IDs

## Files
- `skills/using-n8n-skills/SKILL.md`
- `skills/n8n-node-configuration/SKILL.md`
- `skills/n8n-credentials-and-security/SKILL.md`
- synced `plugins/n8n-skills/...` via `bash scripts/sync-codex-bundle.sh`

## Issue
Fixes #15

## Conflict check
- checked open issue search for `explore_node_resources`, `resource locator`, `RLC`, and `ADO-5278`
- checked PR search for the same terms
- found no open PR covering this issue
- the only related PR I found was closed PR #21, which covered `list_tags` / `search_workflows`, not `explore_node_resources`

## Upstream reference
- n8n PR #31018: merged (`feat(core): Add explore_node_resources MCP tool`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added docs for using `explore_node_resources` to resolve resource‑locator and load‑options fields from the connected account, and added it to the meta‑skill MCP tool list. Guidance now says to pass the method name, credential ID, and `currentNodeParameters`, and to keep the full resource‑locator object; addresses #15.

- **New Features**
  - Added `explore_node_resources` to the tool table in `skills/using-n8n-skills/SKILL.md` and synced `plugins/n8n-skills/...`.
  - Updated node configuration and usage flow: call `explore_node_resources` when `get_node_types` shows a locator/dropdown; pass method name + credential ID + `currentNodeParameters`; keep the returned structured resource‑locator object; use option values for load‑options; added a checklist step to resolve live dropdowns before filling IDs.
  - Updated credential guidance to use `list_credentials` → `explore_node_resources` for live discovery and added an anti‑pattern note against asking for raw IDs.

<sup>Written for commit 8babea091160e4ee8ad1119366d0e219658564b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/skills/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

