### PR TITLE
ci: auto-sync codex bundle on in-repo PRs

### DIFF
--- a/.github/workflows/codex-bundle.yml
+++ b/.github/workflows/codex-bundle.yml
@@ -1,7 +1,9 @@
 name: codex-bundle
 
-# Fails the build if plugins/n8n-skills/ has drifted from the canonical
-# hooks/ + skills/ trees. Regenerate locally with: bash scripts/sync-codex-bundle.sh
+# Keeps plugins/n8n-skills/ (the generated Codex bundle) in sync with the canonical
+# hooks/ + skills/ trees. On in-repo PRs it regenerates the bundle and commits it back
+# to the PR branch; on fork PRs and pushes to main it fails if the bundle is stale.
+# Regenerate locally with: bash scripts/sync-codex-bundle.sh
 
 on:
   pull_request:
@@ -13,16 +15,38 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   verify-bundle:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Check out the branch head (not the PR merge ref) so a regenerated bundle
+          # can be pushed back. Falls back to github.ref for push events.
+          ref: ${{ github.head_ref || github.ref }}
+          persist-credentials: true
       - name: Regenerate Codex bundle
         run: bash scripts/sync-codex-bundle.sh
-      - name: Fail if bundle is out of sync
+      - name: Sync or verify bundle
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
-          if ! git diff --quiet; then
+          if git diff --quiet; then
+            echo "Codex bundle already in sync."
+            exit 0
+          fi
+          # In-repo PR branches: regenerate and commit. GITHUB_TOKEN pushes do not
+          # re-trigger pull_request workflows, so this cannot loop.
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "$IS_FORK" != "true" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -am "chore: sync codex bundle"
+            git push
+            echo "Committed regenerated Codex bundle to ${{ github.head_ref }}."
+          else
             echo "::error::plugins/n8n-skills/ is stale. Run: bash scripts/sync-codex-bundle.sh and commit the result."
             git diff --stat
             exit 1


### PR DESCRIPTION
## What

Changes the `codex-bundle` workflow from a pure drift check into a self-healing sync:

- **In-repo PRs**: regenerate `plugins/n8n-skills/` and commit the result back to the PR branch.
- **Fork PRs and pushes to `main`**: keep the old behaviour, fail if the bundle is stale.

## Why

Contributors frequently forget to run `bash scripts/sync-codex-bundle.sh` after touching `hooks/` or `skills/`, so the build fails on stale bundle drift. Auto-committing the regenerated bundle removes that friction for in-repo branches. `GITHUB_TOKEN` pushes don't re-trigger `pull_request` workflows, so this cannot loop.

## Notes

- Adds `permissions: contents: write` so the job can push.
- Checks out the branch head (`github.head_ref`) rather than the PR merge ref so the regenerated bundle can be pushed back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Codex bundle workflow self-healing: in-repo PRs auto-regenerate and commit `plugins/n8n-skills/`; fork PRs and pushes to `main` still fail if stale. This removes common CI failures when contributors forget to sync the bundle.

- **New Features**
  - In-repo PRs: regenerate and commit the bundle to the PR branch.
  - Fork PRs and `main` pushes: fail with a clear error if the bundle is stale.
  - CI tweaks: add `permissions: contents: write`; checkout `github.head_ref`; commit via `github-actions[bot]`; safe from loops since `GITHUB_TOKEN` pushes don’t retrigger `pull_request`.

<sup>Written for commit d90a8f67a8c5b57a5b5ca9a9459da8d2bc542e9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/skills/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

