### PR TITLE
bundle the n8n MCP connection in the Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "n8n-skills",
       "source": "./",
       "description": "Production-grade n8n workflow building skills for Claude Code. Pairs with the official n8n MCP server.",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "category": "automation",
       "tags": ["n8n", "workflow", "automation", "mcp"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-skills",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Production-grade n8n workflow building skills. Pairs with the official n8n instance-level MCP server to teach Claude how to architect, validate, and ship workflows that work in production.",
   "author": {
     "name": "n8n",
@@ -9,5 +9,19 @@
   "homepage": "https://github.com/n8n-io/skills",
   "repository": "https://github.com/n8n-io/skills",
   "license": "Apache-2.0",
-  "keywords": ["n8n", "workflow", "automation", "mcp"]
+  "keywords": ["n8n", "workflow", "automation", "mcp"],
+  "userConfig": {
+    "n8n_url": {
+      "type": "string",
+      "title": "n8n Base Url (example: https://sub.domain.com)",
+      "description": "Your instance URL only, no path and no trailing slash (e.g. https://sub.domain.com). We add the MCP path for you. Requires n8n 2.2.0+ with Settings > Instance-level MCP enabled.",
+      "required": true
+    }
+  },
+  "mcpServers": {
+    "n8n-mcp": {
+      "type": "http",
+      "url": "${user_config.n8n_url}/mcp-server/http"
+    }
+  }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-skills",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Production-grade n8n workflow building skills. Pairs with the official n8n instance-level MCP server to teach your coding agent how to architect, validate, and ship workflows that work in production.",
   "author": {
     "name": "n8n",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Third person. Starts with "Use when...". Includes trigger keywords a real user w
 - **Temporary workarounds get HTML-comment markers.** Wrap the section with `<!-- TEMPORARY: short description -->` We check each `<!-- TEMPORARY:` after each n8n release.
 - **Hooks never inline skill content.** Hooks emit ~25 tokens of additionalContext at most, naming the canonical Skill-tool path so compaction's skill re-attachment works.
 - **The plugin doesn't edit user AGENT.md / CLAUDE.md files.** README provides a copy-pasteable snippet for users who want it.
+- **Only the Claude plugin bundles the n8n MCP.** `.claude-plugin/plugin.json` ships an `mcpServers` entry whose per-user instance URL is collected via `userConfig` (`${user_config.n8n_url}/mcp-server/http`, prompted at enable time; the field takes the base URL only and the manifest appends the path, since Claude Code substitutes the value verbatim and can't normalize a full URL). Codex can't match this: it has no install-time config prompt and won't expand variables in an MCP `url` (openai/codex#24401 open, #7367 closed "not planned"). So the Codex plugin stays skills/hooks only and users run `codex mcp add n8n-mcp --url .../mcp-server/http` once (documented in README). Revisit if #24401 lands a user-config path. The MCP endpoint is `<instance>/mcp-server/http` (streamable HTTP, OAuth), n8n 2.2.0+.
 
 ## Don't
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Built by the n8n team to pair with n8n's instance-level MCP server. Your coding 
 
 **What's inside:**
 
+- **The n8n MCP connection, set up for you** (Claude Code): the plugin bundles the `n8n-mcp` server and prompts for your instance URL at install, so there's no manual MCP config. Codex adds it with one `codex mcp add`.
 - **13 capability skills** covering best practices across the full workflow lifecycle: sub-workflow reuse, expressions, loops and pagination, AI agents, error handling, credentials, Data Tables, debugging, and more.
 - **50+ reference docs and worked examples** loaded on demand: per-node gotchas, decision trees, and copy-pasteable workflow JSON / TypeScript SDK snippets.
 - **A SessionStart hook** that loads the protocol on every session, including a compact reference for every n8n MCP tool.
@@ -15,45 +16,49 @@ Built by the n8n team to pair with n8n's instance-level MCP server. Your coding 
 
 ## Prerequisite
 
-An n8n instance (any plan, Cloud or self-hosted) with the instance-level MCP server enabled. See [n8n's MCP setup guide](https://docs.n8n.io/advanced-ai/mcp/accessing-n8n-mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=official-skills-repo).
+An n8n instance (any plan, Cloud or self-hosted) with the instance-level MCP server enabled (**Settings → Instance-level MCP**). Minimum **n8n 2.2.0**; for best results, run the latest stable. See [n8n's MCP setup guide](https://docs.n8n.io/build/ways-of-building-workflows/connect-to-n8n-mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=official-skills-repo).
 
 ## Install
 
 Pick your platform:
 
-- [Claude Code](#claude-code)
+- [Claude Code (CLI)](#claude-code-cli)
+- [Claude Code (Desktop app)](#claude-code-desktop-app)
 - [Codex](#codex)
 - [Other platforms](#other-platforms)
 
-### Claude Code
+### Claude Code (CLI)
 
-Inside Claude Code, run these one at a time:
+Inside a `claude` session:
 
-```bash
-/plugin marketplace add n8n-io/skills
-```
+1. **Add the marketplace.** Run `/plugin marketplace add n8n-io/skills`.
+2. **Install the plugin.** Run `/plugin install n8n-skills@n8n-io`, enter your **n8n instance URL** when prompted, then run `/reload-plugins`.
+   - Just the base URL, e.g. `https://acme.app.n8n.cloud` (no path) — the plugin adds `/mcp-server/http`.
+3. **Authorize the MCP.** Run `/mcp`, select **n8n-mcp**, and choose **Authenticate** to sign in via your browser.
 
-```bash
-/plugin install n8n-skills@n8n-io
-```
+> Already run the n8n MCP elsewhere? This adds its own `n8n-mcp` connection. Disable it from `/mcp` to avoid a duplicate toolset.
 
-Restart Claude Code. Skills load automatically.
+### Claude Code (Desktop app)
+
+1. **Add the marketplace.** In the prompt box, run `/plugin marketplace add n8n-io/skills`.
+2. **Install.** Click **+** next to the prompt box → **Plugins** → **Add plugin**, select **n8n-skills** in the plugin browser, and pick a scope. Enter your **n8n instance URL** when prompted (just the base URL, e.g. `https://acme.app.n8n.cloud` — the plugin adds `/mcp-server/http`).
+   - No prompt? Set it with `/plugin configure n8n-skills@n8n-io`, then reload.
+3. **Authorize the MCP.** Open **Settings → Connectors**, find **n8n-mcp**, and connect (browser sign-in).
 
 ### Codex
 
-Run these one at a time:
+> Requires **Codex ≥ 0.142.0** (root-plugin marketplace support). Works in the Codex CLI and the Codex mode of the ChatGPT desktop app.
 
-```bash
-codex plugin marketplace add n8n-io/skills
-```
+In a terminal:
 
-```bash
-codex plugin add n8n-skills@n8n-io
-```
-
-> Requires **Codex ≥ 0.142.0** (root-plugin marketplace support). Works in both the Codex CLI and the Codex mode of the ChatGPT desktop app.
-
-Restart Codex. On first run, Codex prompts to review and trust the plugin's hooks, approve them so the SessionStart, PreToolUse, and PostToolUse reminders fire. Skills load automatically.
+1. **Add the marketplace.** Run `codex plugin marketplace add n8n-io/skills`.
+2. **Install the plugin.** Run `codex plugin add n8n-skills@n8n-io`, then restart Codex and approve the hook-trust prompt (enables the SessionStart, PreToolUse, and PostToolUse reminders).
+3. **Add the MCP server.** Codex can't auto-configure it, so add it once (Codex has no config prompt like Claude Code):
+   ```bash
+   codex mcp add n8n-mcp --url https://<your-n8n-domain>/mcp-server/http
+   ```
+   - No terminal (desktop app only)? Add it in the GUI: **Settings → MCP servers → Add server → Streamable HTTP**, paste the URL, save, then **Restart**.
+4. **Authorize the MCP.** Codex signs in via OAuth on first use, or click **Authenticate** in the MCP servers list.
 
 ### Other platforms
 
@@ -103,8 +108,7 @@ Each skill is a markdown file. Frontmatter tells the agent when to load it. The 
 
 ## Related
 
-- [Official n8n MCP docs](https://docs.n8n.io/advanced-ai/mcp/accessing-n8n-mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=official-skills-repo)
-- [n8n MCP tools reference](https://docs.n8n.io/advanced-ai/mcp/mcp_tools_reference/?utm_source=github&utm_medium=readme&utm_campaign=official-skills-repo)
+- [Connect to the n8n MCP server](https://docs.n8n.io/build/ways-of-building-workflows/connect-to-n8n-mcp-server/?utm_source=github&utm_medium=readme&utm_campaign=official-skills-repo)
 - [n8n](https://n8n.io?utm_source=github&utm_medium=readme&utm_campaign=official-skills-repo)
 
 ## Contributing


### PR DESCRIPTION
Until now the plugin shipped skills + hooks and left the n8n MCP connection for the user to wire up by hand. The Claude Code plugin now **bundles that connection**: it declares the `n8n-mcp` server and collects the instance URL through a `userConfig` prompt at install, so there's no separate MCP setup step. Codex can't prompt for or template a URL, so it stays skills + hooks and users add the MCP with one `codex mcp add` (documented).

## What changed
- **`.claude-plugin/plugin.json`**: new required `userConfig` field (`n8n_url`) + a bundled `mcpServers.n8n-mcp` (`type: http`, `url: ${user_config.n8n_url}/mcp-server/http`).
- **`README.md`**: `Install` split into **Claude Code (CLI)** and **Claude Code (Desktop app)** as numbered steps; Codex section reworked (terminal command + desktop-app GUI path); prerequisite notes the n8n 2.2.0 floor; new "What's inside" bullet for the bundled MCP; fixed two dead n8n doc links.
- **`CLAUDE.md`**: project-fact note on why only Claude bundles the MCP (Codex has no install-time config prompt and can't expand a variable in an MCP `url` — openai/codex#24401, #7367).

## URL handling (and its one sharp edge)
The field takes the **base URL** and the manifest appends `/mcp-server/http`, because Claude Code substitutes `userConfig` values verbatim (no trim / normalize / validation). Verified against a live instance:
- base URL works; base URL *with a trailing slash* → `//mcp-server/http`, which n8n tolerates (401, not 404).
- The one input that breaks is pasting the **full** `.../mcp-server/http` URL → path doubles → 404. The field label and help text steer to "instance URL only, no path."

## Updating (no in-app changelog exists, so noting it here)
Not a breaking change to the skills/hooks contract, but the **setup experience changes**:
- On update, existing users get a new required prompt for their n8n URL, and a new `n8n-mcp` server appears.
- Anyone already running their own n8n MCP gets a second, namespaced `plugin:n8n-skills:n8n-mcp` connection — disable it from `/mcp` or point both at the same instance.
- Skipping the prompt is fine: skills/hooks still load; only the MCP server is withheld until configured.

## Verification
Tested locally against Claude Code **2.1.217** and Codex **0.145.0**:
- Install with `--config n8n_url=https://<host>` resolves to `https://<host>/mcp-server/http`; the server loads as `plugin:n8n-skills:n8n-mcp` (reaches the endpoint, needs-auth).
- OAuth authorizes via `/mcp` → **Authenticate**.
- Endpoint tolerance probed: clean path, trailing slash, and double slash all `401` (route matches); duplicated path `404`s.
- Codex plugin still installs clean; no MCP bundled, as intended.

_writing assistance from claude_

## Housekeeping
- Version `1.0.2` → `1.1.0` across the three manifests. Kept minor: the skills/hooks contract is unchanged and the MCP is additive and skippable.
