### PR TITLE
fix: make hooks portable on Windows

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
+            "commandWindows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.ps1\" session-start",
+            "timeout": 10
           }
         ]
       }
@@ -17,7 +19,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/validate-workflow.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/validate-workflow.sh",
+            "commandWindows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.ps1\" pre-validate-workflow",
+            "timeout": 10
           }
         ]
       },
@@ -26,7 +30,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/create-workflow.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/create-workflow.sh",
+            "commandWindows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.ps1\" pre-create-workflow",
+            "timeout": 10
           }
         ]
       },
@@ -35,7 +41,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/update-workflow.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/update-workflow.sh",
+            "commandWindows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.ps1\" pre-update-workflow",
+            "timeout": 10
           }
         ]
       },
@@ -44,7 +52,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/get-node.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/get-node.sh",
+            "commandWindows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.ps1\" pre-get-node-types",
+            "timeout": 10
           }
         ]
       },
@@ -53,7 +63,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/execute-workflow.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/execute-workflow.sh",
+            "commandWindows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.ps1\" pre-execute-workflow",
+            "timeout": 10
           }
         ]
       },
@@ -62,7 +74,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/test-workflow.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/test-workflow.sh",
+            "commandWindows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.ps1\" pre-test-workflow",
+            "timeout": 10
           }
         ]
       }
@@ -73,7 +87,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use/validate-workflow.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use/validate-workflow.sh",
+            "commandWindows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.ps1\" post-validate-workflow",
+            "timeout": 10
           }
         ]
       }

--- a/hooks/n8n-hooks.mjs
+++ b/hooks/n8n-hooks.mjs
@@ -1,0 +1,401 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const hookDirectory = path.dirname(fileURLToPath(import.meta.url));
+const pluginRoot =
+  process.env.CLAUDE_PLUGIN_ROOT || path.resolve(hookDirectory, "..");
+const stateDirectory =
+  process.env.N8N_SKILLS_STATE_DIR ||
+  path.join(os.tmpdir(), "n8n-skills-state");
+const action = process.argv[2] || "";
+
+const reminders = {
+  "pre-validate-workflow": {
+    marker: "lifecycle-connections",
+    text: "Before validating, run the antipattern scan from n8n-workflow-lifecycle-official references/VALIDATION_CHECKLIST.md section 2 node-by-node: Set nodes feeding only 1 consumer should be inlined; Code nodes doing pure data shaping should be Edit Fields with arrow functions; Merges with 3+ wires need numberOfInputs set explicitly; $json.x in branchy workflows should be $('Node').item.json.x; sub-workflow triggers should be Define Below mode unless receiving binary; DateTime nodes should be Luxon expressions. validate_workflow does not catch any of these; only the manual scan does.",
+  },
+  "pre-create-workflow": {
+    marker: "lifecycle-subworkflows",
+    text: "Before creating: invoke n8n-workflow-lifecycle-official (node groups for logical steps, sticky notes, descriptions, naming) and n8n-subworkflows-official (search existing sub-workflows by tag before duplicating logic) via the Skill tool.",
+  },
+  "pre-update-workflow": {
+    marker: "connections",
+    text: "Before updating: verify connections via get_workflow_details after the update. validate_workflow doesn't catch all multi-IO wiring traps. For Merge node specifics see n8n-node-configuration-official references/MERGE_NODE.md; for per-node error outputs see n8n-error-handling-official references/NODE_ERROR_OUTPUTS.md.",
+  },
+  "pre-execute-workflow": {
+    marker: "error-handling",
+    text: "Before executing: invoke the n8n-error-handling-official skill via the Skill tool. API-shaped workflows (webhook to respond) handle errors on every fallible node. Map status codes to cause: caller's fault is 4xx, your fault is 5xx. Confirm error branches are wired and respond-to-webhook returns a structured response with the right code on failure paths.",
+  },
+  "pre-test-workflow": {
+    marker: "testing",
+    text: "Before testing: invoke the n8n-workflow-lifecycle-official skill via the Skill tool. test_workflow auto-pins triggers, credentialed nodes, and HTTP Request nodes; Code, Edit Fields, If, Data Tables, Execute Command, file ops, and sub-workflow calls run for real. Ask the user before running if any have user-visible side effects. prepare_test_pin_data returns schemas only, you generate the values. Pin data is per-execution only with no visual indicator in the execution viewer; tell the user which nodes were pinned after running.",
+  },
+};
+
+function readInput() {
+  const raw = fs.readFileSync(0, "utf8").trim();
+  return raw ? JSON.parse(raw) : {};
+}
+
+function hookOutput(eventName, additionalContext) {
+  return {
+    hookSpecificOutput: {
+      hookEventName: eventName,
+      additionalContext,
+    },
+  };
+}
+
+function emit(output) {
+  if (output) {
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+  }
+}
+
+function safeSessionId(input) {
+  const sessionId = input?.session_id;
+  if (typeof sessionId !== "string" || !sessionId) {
+    return "";
+  }
+  if (/^[A-Za-z0-9._-]+$/.test(sessionId)) {
+    return sessionId;
+  }
+  return `~${Buffer.from(sessionId, "utf8").toString("base64url")}`;
+}
+
+function markerPath(sessionId, markerName) {
+  return path.join(stateDirectory, `${sessionId}-${markerName}.loaded`);
+}
+
+function ensureStateDirectory() {
+  fs.mkdirSync(stateDirectory, { recursive: true });
+}
+
+function setMarker(sessionId, markerName) {
+  ensureStateDirectory();
+  try {
+    fs.writeFileSync(markerPath(sessionId, markerName), "", { flag: "wx" });
+    return true;
+  } catch (error) {
+    if (error?.code === "EEXIST") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function hasMarker(sessionId, markerName) {
+  return fs.existsSync(markerPath(sessionId, markerName));
+}
+
+function resetMarkers(sessionId) {
+  if (!sessionId || !fs.existsSync(stateDirectory)) {
+    return;
+  }
+  const prefix = `${sessionId}-`;
+  for (const entry of fs.readdirSync(stateDirectory)) {
+    if (entry.startsWith(prefix) && entry.endsWith(".loaded")) {
+      fs.rmSync(path.join(stateDirectory, entry), { force: true });
+    }
+  }
+}
+
+function sessionStart(input) {
+  const sessionId = safeSessionId(input);
+  if (
+    (input?.source === "clear" || input?.source === "compact") &&
+    sessionId
+  ) {
+    resetMarkers(sessionId);
+  }
+
+  try {
+    fs.mkdirSync(path.join(os.homedir(), ".cache", "n8n-skills"), {
+      recursive: true,
+    });
+  } catch {
+    // The cache is optional and the hook must fail open.
+  }
+
+  const metaSkill = path.join(
+    pluginRoot,
+    "skills",
+    "using-n8n-skills-official",
+    "SKILL.md",
+  );
+  if (!fs.existsSync(metaSkill)) {
+    return null;
+  }
+  return hookOutput("SessionStart", fs.readFileSync(metaSkill, "utf8"));
+}
+
+function oneShotReminder(input, reminder) {
+  const sessionId = safeSessionId(input);
+  if (!sessionId || !setMarker(sessionId, reminder.marker)) {
+    return null;
+  }
+  return hookOutput("PreToolUse", reminder.text);
+}
+
+function nodeNames(input) {
+  const ids = input?.tool_input?.ids;
+  if (!Array.isArray(ids)) {
+    return [];
+  }
+  return ids
+    .map((id) => (id && typeof id === "object" ? id.name : id))
+    .filter((name) => typeof name === "string");
+}
+
+function matchesNode(names, expression) {
+  return names.some((name) => expression.test(name));
+}
+
+function getNodeTypesReminder(input) {
+  const sessionId = safeSessionId(input);
+  if (!sessionId) {
+    return null;
+  }
+
+  ensureStateDirectory();
+  const names = nodeNames(input);
+  const warnings = [];
+
+  if (!hasMarker(sessionId, "node-config")) {
+    warnings.push(
+      "Before configuring nodes: invoke the n8n-node-configuration-official skill via the Skill tool. Operation-aware configuration, property dependencies, never assume parameters. Always inspect via the type definitions you're about to fetch.",
+    );
+    setMarker(sessionId, "node-config");
+  }
+
+  if (matchesNode(names, /(^|\.)set$/i)) {
+    warnings.push(`[Set node detected in this lookup]
+STOP and invoke the n8n-expressions-official skill via the Skill tool NOW. The most common antipattern in this whole pack: Set nodes feeding only ONE downstream consumer.
+
+If the only purpose of this Set node is to map fields for the next node (before an Insert/Update Data Table node, before an Email/Slack body, before a Respond to Webhook, etc.), DELETE the Set node and put the expressions DIRECTLY in the next node's parameter slots. The Data Table Insert node has expression slots for every column. The Email node has an expression slot for the body. Use them.
+
+A Set node is only justified when 2+ downstream consumers reference the same derived value, OR when branches converge and need a stable shape (use a NoOp node in that case for naming, not a Set), OR as the FINAL node of a sub-workflow shaping the return contract (the implicit consumer is every caller, so it earns its place as the API boundary; name it 'Return').`);
+  }
+
+  if (matchesNode(names, /(^|\.)code$/i)) {
+    warnings.push(`[Code node detected in this lookup]
+STOP and invoke the n8n-code-nodes-official skill via the Skill tool NOW. Decision order: expression first, then arrow function inside Edit Fields, THEN Code node only if those genuinely cannot do the job.
+
+Default to JavaScript. Only use Python when the user explicitly asked for it ("use Python", "I'm a Python shop"). The user mentioning data analysis is NOT an explicit ask.
+
+Valid Code-node use cases are narrow: multi-source aggregation across the whole dataset ($('A').all() AND $('B').all() in one place), external libraries (lodash etc.), or stateful transforms. NOT "transform one item's fields with .map/.filter/.find", that's Edit Fields with an arrow function expression, much cleaner.
+
+DO NOT reach for Code just because the operation involves crypto or XML. Both have native n8n nodes:
+- Crypto/HMAC/hashing: use the Crypto node (n8n-nodes-base.crypto). It does SHA, HMAC, encrypt/decrypt, random.
+- XML/SOAP/RSS parsing: use the XML node (n8n-nodes-base.xml). After parsing, the result is plain JSON; extract fields with Edit Fields and arrow functions, not another Code node.
+These are the most common false positives for 'this needs a Code node'.
+
+PER-OPERATION CHECK. A Code node doing N things probably has N native answers. Read the body and ask for EACH operation:
+- this.helpers.httpRequest(...) -> use the HTTP Request node.
+- Manual pagination loop (while (more) { start += page; ... }) -> HTTP Request's Pagination option.
+- Regex parsing structured response (/<id>...<\\/id>/g, etc.) -> XML node for XML, JSON.parse for JSON.
+- crypto.createHash / crypto.createHmac -> Crypto node.
+
+Identity Code nodes (return $('SomeNode').all() or return $input.all()) are ALWAYS WRONG. They re-emit upstream data, which means the workflow shape is wrong: the downstream consumer should branch off the upstream directly, or the per-item-vs-aggregate context mismatch should be solved with fan-out, not a Code-node bridge.
+
+Quick tests:
+- Can you describe the Code node's job as "take this one item and..."? If yes, wrong tool.
+- Did you search_nodes for the operation before writing Code? Crypto, XML, regex, date math, HTTP, file I/O all have native nodes or expression-level support.`);
+  }
+
+  if (matchesNode(names, /(^|\.)merge$/i)) {
+    warnings.push(`[Merge node detected in this lookup]
+STOP and invoke the n8n-node-configuration-official skill via the Skill tool, especially references/MERGE_NODE.md, NOW. Two silent failure modes:
+
+1. Merge defaults to 2 inputs. If 3+ sources converge into this Merge, set numberOfInputs explicitly (or the equivalent param on your n8n version) to match. Otherwise the third+ sources silently drop at runtime even though the connection lines are drawn.
+
+2. useDataOfInput is 1-indexed but .input(n) is 0-indexed. Translation rule: useDataOfInput: "N" matches .input(N - 1). Off-by-one silently passes data from the wrong branch.`);
+  }
+
+  if (matchesNode(names, /(^|\.)splitInBatches$/i)) {
+    warnings.push(`[Loop Over Items (splitInBatches) detected in this lookup]
+STOP and invoke the n8n-loops-official skill via the Skill tool NOW.
+
+First question: do you actually need this? Default per-item iteration probably handles your case WITHOUT a Loop Over Items node. Just connect the source to the consumer; n8n iterates automatically. Loop Over Items is for: rate limiting (process N at a time with a Wait between), chunked bulk API calls, per-batch error handling, polling a long-running job (with reset: true and a $runIndex safety ceiling).
+
+Output indexes (this is a common slip): output 0 is DONE (fires once at end), output 1 is LOOP (fires per batch). Easy to wire backwards.`);
+  }
+
+  if (matchesNode(names, /(^|\.)dateTime$/i)) {
+    warnings.push(`[DateTime node detected in this lookup]
+STOP. The DateTime node is almost always wrong. Invoke the n8n-expressions-official skill via the Skill tool NOW.
+
+Date math, formatting, and parsing all work in Luxon expressions inline at the consumer field:
+  {{ DateTime.fromISO($('Source').item.json.created_at).toFormat('yyyy-MM-dd') }}
+  {{ DateTime.now().minus({ days: 7 }).toISO() }}
+
+If you genuinely need the DateTime node (rare), justify it explicitly. Default is: use Luxon in the consumer's expression slot, no separate node.`);
+  }
+
+  if (matchesNode(names, /(^|\.)dataTable$/i)) {
+    warnings.push(`[Data Table node detected in this lookup]
+STOP and invoke the n8n-data-tables-official skill via the Skill tool NOW. Several gotchas that catch people:
+
+1. THREE COLUMNS ARE SYSTEM-MANAGED: id (auto-serial), createdAt, updatedAt. Don't declare them; they're always there. Use them in queries.
+
+2. NO JSON / OBJECT / ARRAY COLUMN TYPES. Only string / number / boolean / date. For nested data, use a string column with JSON.stringify() on write and JSON.parse() on read, postfixed with _object (key_insights_object, topics_object). The postfix is the contract.
+
+3. STORAGE FORMAT IS NOT INTERFACE FORMAT. If your sub-workflow stores arrays as stringified _object columns, parse them BEFORE returning. Don't make callers JSON.parse storage details. Both fresh-path and cached-path returns must produce the SAME natural shape.
+
+4. NO FOREIGN KEYS, but design relationally. Reference rows by id, name columns explicitly (paper_id, customer_id), enforce integrity in workflow logic. n8n won't cascade.
+
+5. THE 'CURRENTLY NO ITEMS EXIST' UI QUIRK is real. SDK saves manual mapping as { mappingMode: 'defineBelow', value: {...} }; the UI's renderer expects schema array too and shows empty without it. Runtime persists fine. Verify via get_workflow_details, don't add a Set node to 'fix' it.
+
+6. ANCHOR DATA REFERENCES TO STABLE NODES. Don't reference $json.x in column slots when an intermediate (HTTP file response, Extract from File, Aggregate) stripped json. Use $('Source Node').item.json.x or a Merge convergence anchor. Silent NULL columns in inserts are how this trap surfaces.
+
+7. DON'T ADD A SET NODE BEFORE INSERT to 'shape the input.' Map directly in the Insert node's per-column slots, OR rename upstream fields to enable auto-map mode.`);
+  }
+
+  return warnings.length
+    ? hookOutput("PreToolUse", warnings.join("\n\n"))
+    : null;
+}
+
+function postValidateWorkflow(input) {
+  const code =
+    typeof input?.tool_input?.code === "string" ? input.tool_input.code : "";
+  if (!code) {
+    return hookOutput(
+      "PostToolUse",
+      "[validate_workflow returned. Validation is necessary, not sufficient.] If n8n-workflow-lifecycle-official is not already in your context, load it via the Skill tool and walk references/VALIDATION_CHECKLIST.md section 2 before publish.",
+    );
+  }
+
+  const has = (signature) => code.includes(signature);
+  const detectedFlags = {
+    Set: has("n8n-nodes-base.set"),
+    Code: has("n8n-nodes-base.code"),
+    Merge: has("n8n-nodes-base.merge"),
+    Loop: has("n8n-nodes-base.splitInBatches"),
+    DateTime: has("n8n-nodes-base.dateTime"),
+    SubWorkflowTrigger: has("n8n-nodes-base.executeWorkflowTrigger"),
+    DataTable: has("n8n-nodes-base.dataTable"),
+    Agent: has("n8n-nodes-langchain.agent"),
+    Webhook: has("n8n-nodes-base.webhook"),
+    HttpRequest: has("n8n-nodes-base.httpRequest"),
+    RespondToWebhook: has("n8n-nodes-base.respondToWebhook"),
+    Schedule: has("n8n-nodes-base.scheduleTrigger"),
+  };
+  const hasChatTrigger = has("langchain.chatTrigger");
+  const hasNewCredential = has("newCredential(");
+  const hasDollarJson = /\$json\./.test(code);
+  const nodeCount = (code.match(/type:\s*['"]n8n-/g) || []).length;
+
+  const suggestions = [];
+  if (detectedFlags.Merge) {
+    suggestions.push(
+      "n8n-node-configuration-official references/MERGE_NODE.md (Merge: numberOfInputs vs wire count, useDataOfInput off-by-one)",
+    );
+  }
+
+  const expressionReasons = [];
+  if (detectedFlags.Set) expressionReasons.push("Set antipattern");
+  if (detectedFlags.DateTime) expressionReasons.push("DateTime → Luxon");
+  if (hasDollarJson) expressionReasons.push("$json refs");
+  if (expressionReasons.length) {
+    suggestions.push(
+      `n8n-expressions-official (${expressionReasons.join(", ")})`,
+    );
+  }
+  if (detectedFlags.Code) {
+    suggestions.push(
+      "n8n-code-nodes-official (Code detected: alternatives review)",
+    );
+  }
+  if (detectedFlags.Loop || detectedFlags.HttpRequest) {
+    suggestions.push("n8n-loops-official (Loop Over Items / pagination)");
+  }
+  if (detectedFlags.SubWorkflowTrigger) {
+    suggestions.push(
+      "n8n-subworkflows-official (sub-workflow trigger: Define Below mode + return-shape rules)",
+    );
+  }
+  if (detectedFlags.DataTable) {
+    suggestions.push(
+      "n8n-data-tables-official (Data Table: schema, dedup, _object column rules)",
+    );
+  }
+  if (
+    hasNewCredential ||
+    detectedFlags.HttpRequest ||
+    detectedFlags.Webhook ||
+    detectedFlags.RespondToWebhook
+  ) {
+    suggestions.push(
+      "n8n-credentials-and-security-official (auth surface present)",
+    );
+  }
+  if (
+    detectedFlags.Webhook ||
+    detectedFlags.RespondToWebhook ||
+    detectedFlags.Schedule ||
+    hasChatTrigger ||
+    detectedFlags.Agent
+  ) {
+    suggestions.push(
+      "n8n-error-handling-official (unattended / webhook workflow: error branches required)",
+    );
+  }
+  if (nodeCount > 6) {
+    suggestions.push(
+      "n8n-workflow-lifecycle-official (>6 nodes: sticky notes, descriptions capturing the why)",
+    );
+  }
+  if (detectedFlags.Agent) {
+    suggestions.push(
+      "n8n-agents-official (LangChain agent detected)",
+    );
+  }
+
+  const detected =
+    Object.entries(detectedFlags)
+      .filter(([, present]) => present)
+      .map(([name]) => name)
+      .join(" ") || "(none of the high-risk node types)";
+
+  let context = `[validate_workflow returned. Validation is necessary, not sufficient.]
+Workflow analyzed: ${nodeCount} node(s); detected: ${detected}.
+`;
+  if (suggestions.length) {
+    context += `
+If any of these skills are not already in your context, load them via the Skill tool:
+- ${suggestions.join("\n- ")}
+
+This is the gate. Walk these BEFORE publish_workflow. Validation passing means the SDK is well-formed; it does NOT mean the workflow is correct.`;
+  } else {
+    context += `
+No high-risk patterns surfaced. If anything in this workflow is non-trivial, load n8n-workflow-lifecycle-official via the Skill tool and walk references/VALIDATION_CHECKLIST.md section 2 before publish.`;
+  }
+  return hookOutput("PostToolUse", context);
+}
+
+function run(input) {
+  if (action === "session-start") {
+    return sessionStart(input);
+  }
+  if (action === "pre-get-node-types") {
+    return getNodeTypesReminder(input);
+  }
+  if (action === "post-validate-workflow") {
+    return postValidateWorkflow(input);
+  }
+  if (reminders[action]) {
+    return oneShotReminder(input, reminders[action]);
+  }
+  return null;
+}
+
+try {
+  emit(run(readInput()));
+} catch {
+  // Hooks are advisory. Fail open instead of blocking a Codex or Claude session.
+}

--- a/hooks/n8n-hooks.test.mjs
+++ b/hooks/n8n-hooks.test.mjs
@@ -1,0 +1,355 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test, { after } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const hookScript = path.join(testDirectory, "n8n-hooks.mjs");
+const windowsRunner = path.join(testDirectory, "run-hook.ps1");
+const fixtureRoot = fs.mkdtempSync(
+  path.join(os.tmpdir(), "n8n hooks with spaces "),
+);
+const fixtureSkillDirectory = path.join(
+  fixtureRoot,
+  "skills",
+  "using-n8n-skills-official",
+);
+const metaSkillBody = "---\nname: using-n8n-skills-official\n---\nTest body.\n";
+
+fs.mkdirSync(fixtureSkillDirectory, { recursive: true });
+fs.writeFileSync(
+  path.join(fixtureSkillDirectory, "SKILL.md"),
+  metaSkillBody,
+  "utf8",
+);
+
+after(() => {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+function newStateDirectory(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `n8n-hooks-${label}-`));
+}
+
+function invoke(
+  action,
+  input,
+  {
+    pluginRoot = fixtureRoot,
+    stateDirectory = newStateDirectory("state"),
+    pathValue = process.env.PATH,
+  } = {},
+) {
+  const startedAt = Date.now();
+  const result = spawnSync(process.execPath, [hookScript, action], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_ROOT: pluginRoot,
+      N8N_SKILLS_STATE_DIR: stateDirectory,
+      PATH: pathValue,
+    },
+    input:
+      typeof input === "string" ? input : JSON.stringify(input ?? {}),
+    timeout: 10_000,
+  });
+  const stdout = result.stdout.trim();
+  return {
+    ...result,
+    durationMs: Date.now() - startedAt,
+    output: stdout ? JSON.parse(stdout) : null,
+    stateDirectory,
+  };
+}
+
+function assertSuccessful(result) {
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.signal, null);
+  assert.ok(result.durationMs < 10_000);
+}
+
+test("SessionStart supports startup, resume, clear, and compact", () => {
+  const stateDirectory = newStateDirectory("session-events");
+  const sessionId = "session-events";
+
+  for (const source of ["startup", "resume"]) {
+    const result = invoke(
+      "session-start",
+      { session_id: sessionId, source },
+      { stateDirectory },
+    );
+    assertSuccessful(result);
+    assert.equal(
+      result.output.hookSpecificOutput.hookEventName,
+      "SessionStart",
+    );
+    assert.equal(
+      result.output.hookSpecificOutput.additionalContext,
+      metaSkillBody,
+    );
+  }
+
+  const ownMarker = path.join(
+    stateDirectory,
+    `${sessionId}-node-config.loaded`,
+  );
+  const otherMarker = path.join(
+    stateDirectory,
+    "other-session-node-config.loaded",
+  );
+  fs.writeFileSync(ownMarker, "");
+  fs.writeFileSync(otherMarker, "");
+
+  const clearResult = invoke(
+    "session-start",
+    { session_id: sessionId, source: "clear" },
+    { stateDirectory },
+  );
+  assertSuccessful(clearResult);
+  assert.equal(fs.existsSync(ownMarker), false);
+  assert.equal(fs.existsSync(otherMarker), true);
+
+  fs.writeFileSync(ownMarker, "");
+  const compactResult = invoke(
+    "session-start",
+    { session_id: sessionId, source: "compact" },
+    { stateDirectory },
+  );
+  assertSuccessful(compactResult);
+  assert.equal(fs.existsSync(ownMarker), false);
+});
+
+test("SessionStart fails open when the meta-skill is unavailable", () => {
+  const missingRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "n8n-hooks-missing-skill-"),
+  );
+  const result = invoke(
+    "session-start",
+    { session_id: "missing", source: "startup" },
+    { pluginRoot: missingRoot },
+  );
+  assertSuccessful(result);
+  assert.equal(result.output, null);
+  fs.rmSync(missingRoot, { recursive: true, force: true });
+});
+
+test("one-shot PreToolUse reminders deduplicate by session", () => {
+  const actions = [
+    "pre-validate-workflow",
+    "pre-create-workflow",
+    "pre-update-workflow",
+    "pre-execute-workflow",
+    "pre-test-workflow",
+  ];
+
+  for (const action of actions) {
+    const stateDirectory = newStateDirectory(action);
+    const input = { session_id: `session-${action}` };
+    const first = invoke(action, input, { stateDirectory });
+    const second = invoke(action, input, { stateDirectory });
+    assertSuccessful(first);
+    assertSuccessful(second);
+    assert.equal(first.output.hookSpecificOutput.hookEventName, "PreToolUse");
+    assert.ok(first.output.hookSpecificOutput.additionalContext.length > 50);
+    assert.equal(second.output, null);
+  }
+});
+
+test("distinct session IDs cannot share reminder markers", () => {
+  const stateDirectory = newStateDirectory("session-id-collision");
+  const first = invoke(
+    "pre-create-workflow",
+    { session_id: "session/a" },
+    { stateDirectory },
+  );
+  const second = invoke(
+    "pre-create-workflow",
+    { session_id: "session?a" },
+    { stateDirectory },
+  );
+
+  assertSuccessful(first);
+  assertSuccessful(second);
+  assert.ok(first.output);
+  assert.ok(second.output);
+});
+
+test("get_node_types accepts object and string IDs and repeats risk warnings", () => {
+  const stateDirectory = newStateDirectory("get-node");
+  const input = {
+    session_id: "node-session",
+    tool_input: {
+      ids: [
+        { name: "n8n-nodes-base.code", operation: "runOnceForAllItems" },
+        "n8n-nodes-base.dateTime",
+      ],
+    },
+  };
+
+  const first = invoke("pre-get-node-types", input, { stateDirectory });
+  const second = invoke("pre-get-node-types", input, { stateDirectory });
+  assertSuccessful(first);
+  assertSuccessful(second);
+
+  const firstContext = first.output.hookSpecificOutput.additionalContext;
+  const secondContext = second.output.hookSpecificOutput.additionalContext;
+  assert.match(firstContext, /Before configuring nodes/);
+  assert.match(firstContext, /\[Code node detected/);
+  assert.match(firstContext, /\[DateTime node detected/);
+  assert.doesNotMatch(secondContext, /Before configuring nodes/);
+  assert.match(secondContext, /\[Code node detected/);
+  assert.match(secondContext, /\[DateTime node detected/);
+});
+
+test("get_node_types covers every high-risk node warning", () => {
+  const result = invoke("pre-get-node-types", {
+    session_id: "all-risk-nodes",
+    tool_input: {
+      ids: [
+        "n8n-nodes-base.set",
+        "n8n-nodes-base.merge",
+        "n8n-nodes-base.splitInBatches",
+        "n8n-nodes-base.dataTable",
+      ],
+    },
+  });
+  assertSuccessful(result);
+
+  const context = result.output.hookSpecificOutput.additionalContext;
+  assert.match(context, /\[Set node detected/);
+  assert.match(context, /\[Merge node detected/);
+  assert.match(context, /\[Loop Over Items/);
+  assert.match(context, /\[Data Table node detected/);
+});
+
+test("PostToolUse returns the fallback when workflow code is absent", () => {
+  const result = invoke("post-validate-workflow", {
+    session_id: "post-fallback",
+    tool_input: {},
+  });
+  assertSuccessful(result);
+  assert.equal(result.output.hookSpecificOutput.hookEventName, "PostToolUse");
+  assert.match(
+    result.output.hookSpecificOutput.additionalContext,
+    /Validation is necessary, not sufficient/,
+  );
+});
+
+test("PostToolUse detects relevant workflow risks", () => {
+  const code = `
+node({ type: "n8n-nodes-base.set" })
+node({ type: "n8n-nodes-base.code" })
+node({ type: "n8n-nodes-base.merge" })
+node({ type: "n8n-nodes-base.httpRequest" })
+node({ type: "n8n-nodes-base.webhook" })
+node({ type: "n8n-nodes-base.dataTable" })
+node({ type: "n8n-nodes-langchain.agent" })
+const value = $json.value
+newCredential("Label")
+`;
+  const result = invoke("post-validate-workflow", {
+    session_id: "post-analysis",
+    tool_input: { code },
+  });
+  assertSuccessful(result);
+
+  const context = result.output.hookSpecificOutput.additionalContext;
+  assert.match(context, /Workflow analyzed: 7 node/);
+  assert.match(context, /n8n-node-configuration-official/);
+  assert.match(context, /n8n-expressions-official/);
+  assert.match(context, /n8n-code-nodes-official/);
+  assert.match(context, /n8n-loops-official/);
+  assert.match(context, /n8n-data-tables-official/);
+  assert.match(context, /n8n-credentials-and-security-official/);
+  assert.match(context, /n8n-error-handling-official/);
+  assert.match(context, /n8n-workflow-lifecycle-official/);
+  assert.match(context, /n8n-agents-official/);
+});
+
+test("malformed input and unknown actions fail open", () => {
+  const malformed = invoke("session-start", "{not-json");
+  const unknown = invoke("unknown-action", { session_id: "unknown" });
+  assertSuccessful(malformed);
+  assertSuccessful(unknown);
+  assert.equal(malformed.output, null);
+  assert.equal(unknown.output, null);
+});
+
+test("hooks do not require Bash, jq, or Python on PATH", () => {
+  const result = invoke(
+    "session-start",
+    { session_id: "node-only", source: "startup" },
+    { pathValue: path.dirname(process.execPath) },
+  );
+  assertSuccessful(result);
+  assert.equal(
+    result.output.hookSpecificOutput.additionalContext,
+    metaSkillBody,
+  );
+});
+
+test(
+  "Windows runner invokes the dispatcher without node on PATH",
+  { skip: process.platform !== "win32" },
+  () => {
+    const powershell = path.join(
+      process.env.SystemRoot,
+      "System32",
+      "WindowsPowerShell",
+      "v1.0",
+      "powershell.exe",
+    );
+    const result = spawnSync(
+      powershell,
+      [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        windowsRunner,
+        "session-start",
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CLAUDE_PLUGIN_ROOT: fixtureRoot,
+          N8N_SKILLS_NODE_EXE: process.execPath,
+          N8N_SKILLS_STATE_DIR: newStateDirectory("windows-runner"),
+          PATH: "",
+        },
+        input: JSON.stringify({ session_id: "windows", source: "startup" }),
+        timeout: 10_000,
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout.trim());
+    assert.equal(output.hookSpecificOutput.additionalContext, metaSkillBody);
+  },
+);
+
+test("hooks.json keeps POSIX hooks and adds a Windows runner", () => {
+  const config = JSON.parse(
+    fs.readFileSync(path.join(testDirectory, "hooks.json"), "utf8"),
+  );
+  const commands = Object.values(config.hooks).flatMap((groups) =>
+    groups.flatMap((group) => group.hooks),
+  );
+
+  assert.equal(commands.length, 8);
+  for (const hook of commands) {
+    assert.match(
+      hook.command,
+      /^\$\{CLAUDE_PLUGIN_ROOT\}\/hooks\/.+\.sh$/,
+    );
+    assert.match(
+      hook.commandWindows,
+      /^powershell\.exe -NoProfile -ExecutionPolicy Bypass -File "\$\{CLAUDE_PLUGIN_ROOT\}\/hooks\/run-hook\.ps1" [a-z-]+$/,
+    );
+    assert.equal(hook.timeout, 10);
+  }
+});

--- a/hooks/run-hook.ps1
+++ b/hooks/run-hook.ps1
@@ -1,0 +1,27 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$Action
+)
+
+$nodeExecutable = $env:N8N_SKILLS_NODE_EXE
+
+if ([string]::IsNullOrWhiteSpace($nodeExecutable)) {
+  $nodeCommand = Get-Command node.exe -ErrorAction SilentlyContinue
+  if ($null -ne $nodeCommand) {
+    $nodeExecutable = $nodeCommand.Source
+  }
+}
+
+if ([string]::IsNullOrWhiteSpace($nodeExecutable) -and $env:USERPROFILE) {
+  $bundledNode = Join-Path $env:USERPROFILE ".cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe"
+  if (Test-Path -LiteralPath $bundledNode) {
+    $nodeExecutable = $bundledNode
+  }
+}
+
+if ([string]::IsNullOrWhiteSpace($nodeExecutable) -or -not (Test-Path -LiteralPath $nodeExecutable)) {
+  exit 0
+}
+
+& $nodeExecutable (Join-Path $PSScriptRoot "n8n-hooks.mjs") $Action
+exit $LASTEXITCODE


### PR DESCRIPTION
Fixes #40

Supersedes #42 with a current-main Windows override while keeping the existing POSIX hooks.

- add commandWindows via a PowerShell runner
- find system Node or the Codex bundled Node runtime
- preserve existing hook behavior and prevent session-marker collisions
- add Windows and WSL regression coverage

Validation: 12/12 tests on native Windows; 11/11 plus one Windows-only skip on WSL.

Based on #42 by @salomaoparkour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes n8n hooks portable on Windows by adding a PowerShell runner and Node-based dispatcher, while keeping POSIX hooks unchanged. Previously hooks didn’t run on Windows and reminder markers could collide; now Windows runs the same logic and markers are session-scoped.

**New Features**
- Adds `commandWindows` entries in `hooks.json` that invoke `run-hook.ps1`.
- `run-hook.ps1` finds Node via `N8N_SKILLS_NODE_EXE`, PATH, or the bundled Codex runtime.
- Introduces `n8n-hooks.mjs` dispatcher shared across platforms.
- Adds Windows and WSL regression coverage.

**Bug Fixes**
- Deduplicates reminders using collision-safe, per-session markers.
- Hooks fail open and no longer rely on Bash/jq/Python on PATH.
- Applies a 10s timeout per hook to prevent hangs.

<sup>Written for commit e0c898946389bf8aad5ebbb6cbb988486c5b7a2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/skills/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

